### PR TITLE
Parse skipVerify flag as a string when reading from s3 secret

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,16 +5,13 @@ go 1.13
 replace k8s.io/client-go => k8s.io/client-go v0.18.0
 
 require (
-	github.com/ehazlett/simplelog v0.0.0-20200226020431-d374894e92a4
 	github.com/minio/minio-go/v6 v6.0.57
-	github.com/prometheus/common v0.4.1
 	github.com/rancher/lasso v0.0.0-20200515155337-a34e1e26ad91
 	github.com/rancher/wrangler v0.6.2-0.20200622171942-7224e49a2407
 	github.com/rancher/wrangler-api v0.6.1-0.20200515193802-dcf70881b087
 	github.com/robfig/cron v1.2.0
 	github.com/sirupsen/logrus v1.5.0
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
-	gopkg.in/yaml.v2 v2.2.8
 	k8s.io/api v0.18.0
 	k8s.io/apiextensions-apiserver v0.18.0
 	k8s.io/apimachinery v0.18.0

--- a/go.sum
+++ b/go.sum
@@ -63,8 +63,6 @@ github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZ
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
-github.com/ehazlett/simplelog v0.0.0-20200226020431-d374894e92a4 h1:v9kqlO59x6QpNXctFc+yiWy6dUb+x5x8e9uPUAu1Taw=
-github.com/ehazlett/simplelog v0.0.0-20200226020431-d374894e92a4/go.mod h1:m8BGliBtT1XxrkLygibAe1L4gWruiNqNUmukTUwGlcY=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful v2.9.5+incompatible h1:spTtZBk5DYEvbxMVutUuTyh1Ao2r4iyvLdACqsl/Ljk=


### PR DESCRIPTION
The stringData of the s3 secret cannot accept insecureSkipVerify input as a boolean flag.
The helm chart will now quote that field converting the input from bool to string.
And the backup-restore-operator will unmarshal secret.StringData into a temporary objectStore
struct with insecureSkipVerify as a string, and then set it as a bool in the original s3ObjectStore type

https://github.com/rancher/backup-restore-operator/issues/56