### PR TITLE
Update to MkdirAll to handle subfolders

### DIFF
--- a/pkg/controllers/backup/controller.go
+++ b/pkg/controllers/backup/controller.go
@@ -254,7 +254,7 @@ func (h *handler) performBackup(backup *v1.Backup, tmpBackupPath, backupFileName
 		return err
 	}
 	filtersPath := filepath.Join(tmpBackupPath, "filters")
-	err = os.Mkdir(filtersPath, os.ModePerm)
+	err = os.MkdirAll(filtersPath, os.ModePerm)
 	if err != nil {
 		return err
 	}

--- a/pkg/controllers/backup/upload.go
+++ b/pkg/controllers/backup/upload.go
@@ -21,7 +21,7 @@ func (h *handler) uploadToS3(backup *v1.Backup, objectStore *v1.S3ObjectStore, t
 		return err
 	}
 	if objectStore.Folder != "" {
-		if err := os.Mkdir(filepath.Join(tmpBackupGzipFilepath, objectStore.Folder), os.ModePerm); err != nil {
+		if err := os.MkdirAll(filepath.Join(tmpBackupGzipFilepath, objectStore.Folder), os.ModePerm); err != nil {
 			return removeTempUploadDir(tmpBackupGzipFilepath, err)
 		}
 		gzipFile = fmt.Sprintf("%s/%s", objectStore.Folder, gzipFile)

--- a/pkg/resourcesets/collector.go
+++ b/pkg/resourcesets/collector.go
@@ -472,7 +472,7 @@ func (h *ResourceHandler) WriteBackupObjects(backupPath string) error {
 func createResourceDir(path string) error {
 	_, err := os.Stat(path)
 	if os.IsNotExist(err) {
-		err = os.Mkdir(path, os.ModePerm)
+		err = os.MkdirAll(path, os.ModePerm)
 		if err != nil {
 			return fmt.Errorf("error creating temp dir: %v", err)
 		}


### PR DESCRIPTION
Tested with a dapper-built image (`derekdemo/rancher-bro:dev`).

Subfolder and backup file was created in S3 without errors and expected data.

Issue: https://github.com/rancher/backup-restore-operator/issues/63