### PR TITLE
[DNM 2.5.7] Add charts from rancher/charts

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -1,0 +1,20 @@
+# Developing
+
+Developer tips, tricks, and workflows for the [rancher/backup-restore-operator](https://github.com/rancher/backup-restore-operator).
+
+### Developer Installation
+
+To test your local changes, `cd` to the root of the cloned repository, and execute the following commands:
+
+```bash
+helm install --wait \
+    --create-namespace -n cattle-resources-system \
+    rancher-backup-crd ./charts/rancher-backup-crd
+helm install --wait \
+    -n cattle-resources-system \
+    rancher-backup ./charts/rancher-backup
+```
+
+### Developer Uninstallation
+
+Follow the uninstallation instructions in [README.md](./README.md).

--- a/README.md
+++ b/README.md
@@ -1,11 +1,49 @@
 # Backup and Restore Operator
 
-
 ### Description
 
 * This operator provides ability to backup and restore Kubernetes applications (metadata) running on any cluster. It accepts a list of resources that need to be backed up for a particular application. It then gathers these resources by querying the Kubernetes API server, packages all the resources to create a tarball file and pushes it to the configured backup storage location. Since it gathers resources by quering the API server, it can back up applications from any type of Kubernetes cluster.
-* The operator preserves the ownerReferences on all resources, hence maintaining dependencies between objects. 
+* The operator preserves the ownerReferences on all resources, hence maintaining dependencies between objects.
 * It also provides encryption support, to encrypt user specified resources before saving them in the backup file. It uses the same encryption configuration that is used to enable [Kubernetes Encryption at Rest](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/). Follow the steps in [documentation link TBD] to configure this.
+
+----
+
+### Quickstart
+
+If Rancher v2.5+ is installed, you can install the `backup-restore-operator`, from the [Cluster Explorer UI](https://rancher.com/docs/rancher/v2.x/en/backups/v2.5/).
+Otherwise, you can install the charts via `helm repo` by executing the commands below.
+
+First, add our charts repository.
+
+```bash
+helm repo add rancher-charts https://raw.githubusercontent.com/rancher/charts/release-v2.5/
+helm repo update
+```
+
+Then, install both charts.
+Ensure that the CRD chart is installed first.
+
+```bash
+helm install --wait \
+    --create-namespace -n cattle-resources-system \
+    rancher-backup-crd rancher-charts/rancher-backup-crd
+helm install --wait \
+    -n cattle-resources-system \
+    rancher-backup rancher-charts/rancher-backup
+```
+
+----
+
+### Uninstallation
+
+If you are uninstalling and want to keep backup(s), ensure that you have created Backup CR(s) and that your backups are stored in a safe location.
+Execute the following commands to uninstall:
+
+```bash
+helm uninstall -n cattle-resources-system rancher-backup
+helm uninstall -n cattle-resources-system rancher-backup-crd
+kubectl delete namespace cattle-resources-system
+```
 
 ----
 
@@ -14,9 +52,9 @@
 It installs the following cluster-scoped CRDs:
 #### Backup
   A backup can be performed by creating an instance of the Backup CRD. It can be configured to perform a one-time backup, or to schedule recurring backups.
-#### Restore  
-  Creating an instance of the Restore CRD lets you restore from a backup file. 
-#### ResourceSet  
+#### Restore
+  Creating an instance of the Restore CRD lets you restore from a backup file.
+#### ResourceSet
   ResourceSet specifies the Kubernetes core resources and CRDs that need to be backed up. This chart comes with a predetermined ResourceSet to be used for backing up Rancher application
 
 ----
@@ -25,3 +63,9 @@ It installs the following cluster-scoped CRDs:
 1. Create a ResourceSet, that targets all the resources you want to backup. The ResourceSet required for backing up Rancher will be provided and installed by the chart. Refer to the default [rancher-resource-set](https://github.com/rancher/backup-restore-operator/blob/master/crds/rancher-resource-set.yaml) as an example for creating resourceSets
 2. Performing a backup: To take a backup, user has to create an instance of the Backup CRD (create a Backup CR). Each Backup CR must reference a ResourceSet. A Backup CR can be used to perform a one-time backup or recurring backups. Refer [examples](https://github.com/rancher/backup-restore-operator/tree/master/examples) folder for sample manifests
 3. Restoring from a backup: To restore from a backup, user has to create an instance of the Restore CRD (create a Restore CR). A Restore CR must contain the exact Backup filename.  Refer [examples](https://github.com/rancher/backup-restore-operator/tree/master/examples) folder for sample manifests
+
+---
+
+### Developer Documentation
+
+Refer to [DEVELOPING.md](./DEVELOPING.md) for developer tips, tricks, and workflows when working with the `backup-restore-operator`.

--- a/charts/rancher-backup-crd/Chart.yaml
+++ b/charts/rancher-backup-crd/Chart.yaml
@@ -1,10 +1,11 @@
+apiVersion: v2
+name: rancher-backup-crd
+appVersion: 999
+version: 999
+description: Installs the CRDs for rancher-backup.
+type: application
 annotations:
   catalog.cattle.io/certified: rancher
   catalog.cattle.io/hidden: "true"
   catalog.cattle.io/namespace: cattle-resources-system
   catalog.cattle.io/release-name: rancher-backup-crd
-apiVersion: v1
-description: Installs the CRDs for rancher-backup.
-name: rancher-backup-crd
-type: application
-version: 1.0.301-rc01

--- a/charts/rancher-backup-crd/Chart.yaml
+++ b/charts/rancher-backup-crd/Chart.yaml
@@ -1,0 +1,10 @@
+annotations:
+  catalog.cattle.io/certified: rancher
+  catalog.cattle.io/hidden: "true"
+  catalog.cattle.io/namespace: cattle-resources-system
+  catalog.cattle.io/release-name: rancher-backup-crd
+apiVersion: v1
+description: Installs the CRDs for rancher-backup.
+name: rancher-backup-crd
+type: application
+version: 1.0.301-rc01

--- a/charts/rancher-backup-crd/README.md
+++ b/charts/rancher-backup-crd/README.md
@@ -1,0 +1,2 @@
+# rancher-backup-crd
+A Rancher chart that installs the CRDs used by rancher-backup.

--- a/charts/rancher-backup-crd/README.md
+++ b/charts/rancher-backup-crd/README.md
@@ -1,2 +1,3 @@
-# rancher-backup-crd
-A Rancher chart that installs the CRDs used by rancher-backup.
+# Rancher Backup CRD
+
+A Rancher chart that installs the CRDs used by `rancher-backup`.

--- a/charts/rancher-backup-crd/templates/backup.yaml
+++ b/charts/rancher-backup-crd/templates/backup.yaml
@@ -1,0 +1,119 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: backups.resources.cattle.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.storageLocation
+    name: Location
+    type: string
+  - JSONPath: .status.backupType
+    name: Type
+    type: string
+  - JSONPath: .status.filename
+    name: Latest-Backup
+    type: string
+  - JSONPath: .spec.resourceSetName
+    name: ResourceSet
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
+  - JSONPath: .status.conditions[?(@.type=="Ready")].message
+    name: Status
+    type: string
+  group: resources.cattle.io
+  names:
+    kind: Backup
+    plural: backups
+  scope: Cluster
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          properties:
+            encryptionConfigSecretName:
+              description: Name of the Secret containing the encryption config
+              type: string
+            resourceSetName:
+              description: Name of the ResourceSet CR to use for backup
+              type: string
+            retentionCount:
+              minimum: 1
+              type: integer
+            schedule:
+              description: Cron schedule for recurring backups
+              example:
+                Descriptors: '@midnight'
+                Standard crontab specs: 0 0 * * *
+              type: string
+            storageLocation:
+              nullable: true
+              properties:
+                s3:
+                  nullable: true
+                  properties:
+                    bucketName:
+                      type: string
+                    credentialSecretName:
+                      type: string
+                    credentialSecretNamespace:
+                      type: string
+                    endpoint:
+                      type: string
+                    endpointCA:
+                      type: string
+                    folder:
+                      type: string
+                    insecureTLSSkipVerify:
+                      type: boolean
+                    region:
+                      type: string
+                  type: object
+              type: object
+          required:
+          - resourceSetName
+          type: object
+        status:
+          properties:
+            backupType:
+              type: string
+            conditions:
+              items:
+                properties:
+                  lastTransitionTime:
+                    type: string
+                  lastUpdateTime:
+                    type: string
+                  message:
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                type: object
+              nullable: true
+              type: array
+            filename:
+              type: string
+            lastSnapshotTs:
+              type: string
+            nextSnapshotAt:
+              type: string
+            observedGeneration:
+              type: integer
+            storageLocation:
+              type: string
+            summary:
+              type: string
+          type: object
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true

--- a/charts/rancher-backup-crd/templates/resourceset.yaml
+++ b/charts/rancher-backup-crd/templates/resourceset.yaml
@@ -1,0 +1,94 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: resourcesets.resources.cattle.io
+spec:
+  group: resources.cattle.io
+  names:
+    kind: ResourceSet
+    plural: resourcesets
+  scope: Cluster
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        controllerReferences:
+          items:
+            properties:
+              apiVersion:
+                type: string
+              name:
+                type: string
+              namespace:
+                type: string
+              replicas:
+                type: integer
+              resource:
+                type: string
+            type: object
+          nullable: true
+          type: array
+        resourceSelectors:
+          items:
+            properties:
+              apiVersion:
+                type: string
+              kinds:
+                items:
+                  type: string
+                nullable: true
+                type: array
+              kindsRegexp:
+                type: string
+              labelSelectors:
+                nullable: true
+                properties:
+                  matchExpressions:
+                    items:
+                      properties:
+                        key:
+                          type: string
+                        operator:
+                          type: string
+                        values:
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                      type: object
+                    nullable: true
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    nullable: true
+                    type: object
+                type: object
+              namespaceRegexp:
+                type: string
+              namespaces:
+                items:
+                  type: string
+                nullable: true
+                type: array
+              resourceNameRegexp:
+                type: string
+              resourceNames:
+                items:
+                  type: string
+                nullable: true
+                type: array
+            type: object
+          nullable: true
+          required:
+          - apiVersion
+          type: array
+      required:
+      - resourceSelectors
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true

--- a/charts/rancher-backup-crd/templates/restore.yaml
+++ b/charts/rancher-backup-crd/templates/restore.yaml
@@ -1,0 +1,102 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: restores.resources.cattle.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.backupSource
+    name: Backup-Source
+    type: string
+  - JSONPath: .spec.backupFilename
+    name: Backup-File
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
+  - JSONPath: .status.conditions[?(@.type=="Ready")].message
+    name: Status
+    type: string
+  group: resources.cattle.io
+  names:
+    kind: Restore
+    plural: restores
+  scope: Cluster
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          properties:
+            backupFilename:
+              type: string
+            deleteTimeoutSeconds:
+              maximum: 10
+              type: integer
+            encryptionConfigSecretName:
+              type: string
+            prune:
+              nullable: true
+              type: boolean
+            storageLocation:
+              nullable: true
+              properties:
+                s3:
+                  nullable: true
+                  properties:
+                    bucketName:
+                      type: string
+                    credentialSecretName:
+                      type: string
+                    credentialSecretNamespace:
+                      type: string
+                    endpoint:
+                      type: string
+                    endpointCA:
+                      type: string
+                    folder:
+                      type: string
+                    insecureTLSSkipVerify:
+                      type: boolean
+                    region:
+                      type: string
+                  type: object
+              type: object
+          required:
+          - backupFilename
+          type: object
+        status:
+          properties:
+            backupSource:
+              type: string
+            conditions:
+              items:
+                properties:
+                  lastTransitionTime:
+                    type: string
+                  lastUpdateTime:
+                    type: string
+                  message:
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                type: object
+              nullable: true
+              type: array
+            observedGeneration:
+              type: integer
+            restoreCompletionTs:
+              type: string
+            summary:
+              type: string
+          type: object
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true

--- a/charts/rancher-backup/Chart.yaml
+++ b/charts/rancher-backup/Chart.yaml
@@ -1,3 +1,13 @@
+apiVersion: v2
+name: rancher-backup
+appVersion: 999
+version: 999
+description: Provides ability to back up and restore the Rancher application running
+  on any Kubernetes cluster
+icon: https://charts.rancher.io/assets/logos/backup-restore.svg
+keywords:
+- applications
+- infrastructure
 annotations:
   catalog.cattle.io/auto-install: rancher-backup-crd=match
   catalog.cattle.io/certified: rancher
@@ -8,13 +18,3 @@ annotations:
   catalog.cattle.io/release-name: rancher-backup
   catalog.cattle.io/scope: management
   catalog.cattle.io/ui-component: rancher-backup
-apiVersion: v1
-appVersion: v1.0.3
-description: Provides ability to back up and restore the Rancher application running
-  on any Kubernetes cluster
-icon: https://charts.rancher.io/assets/logos/backup-restore.svg
-keywords:
-- applications
-- infrastructure
-name: rancher-backup
-version: 1.0.301-rc01

--- a/charts/rancher-backup/Chart.yaml
+++ b/charts/rancher-backup/Chart.yaml
@@ -1,0 +1,20 @@
+annotations:
+  catalog.cattle.io/auto-install: rancher-backup-crd=match
+  catalog.cattle.io/certified: rancher
+  catalog.cattle.io/display-name: Rancher Backups
+  catalog.cattle.io/namespace: cattle-resources-system
+  catalog.cattle.io/os: linux
+  catalog.cattle.io/provides-gvr: resources.cattle.io.resourceset/v1
+  catalog.cattle.io/release-name: rancher-backup
+  catalog.cattle.io/scope: management
+  catalog.cattle.io/ui-component: rancher-backup
+apiVersion: v1
+appVersion: v1.0.3
+description: Provides ability to back up and restore the Rancher application running
+  on any Kubernetes cluster
+icon: https://charts.rancher.io/assets/logos/backup-restore.svg
+keywords:
+- applications
+- infrastructure
+name: rancher-backup
+version: 1.0.301-rc01

--- a/charts/rancher-backup/README.md
+++ b/charts/rancher-backup/README.md
@@ -1,0 +1,69 @@
+# Rancher Backup
+
+This chart provides ability to back up and restore the Rancher application running on any Kubernetes cluster.
+
+Refer [this](https://github.com/rancher/backup-restore-operator) repository for implementation details.
+
+-----
+
+### Get Repo Info
+```
+helm repo add rancher-chart https://charts.rancher.io
+helm repo update
+```
+
+-----
+
+### Install Chart
+```
+helm install rancher-backup-crd rancher-chart/rancher-backup-crd -n cattle-resources-system --create-namespace
+helm install rancher-backup rancher-chart/rancher-backup -n cattle-resources-system
+```
+
+-----
+
+### Configuration
+The following table lists the configurable parameters of the rancher-backup chart and their default values:
+
+| Parameter   |      Description      |  Default |
+|----------|---------------|-------|
+| image.repository |  Container image repository | rancher/backup-restore-operator |
+| image.tag |    Container image tag  |   v0.1.0-rc1 |
+| s3.enabled | Configure S3 compatible default storage location. Current version supports S3 and MinIO |    false |
+| s3.credentialSecretName | Name of the Secret containing S3 credentials. This is an optional field. Skip this field in order to use IAM Role authentication. The Secret must contain following two keys, `accessKey` and `secretKey` |    "" |
+| s3.credentialSecretNamespace | Namespace of the Secret containing S3 credentials. This can be any namespace. |    "" |
+| s3.region | Region of the S3 Bucket (Required for S3, not valid for MinIO) |    "" |
+| s3.bucketName | Name of the Bucket |    "" |
+| s3.folder | Base folder within the Bucket (optional) |    "" |
+| s3.endpoint | Endpoint for the S3 storage provider |   "" |
+| s3.endpointCA | Base64 encoded CA cert for the S3 storage provider (optional) | "" |
+| s3.insecureTLSSkipVerify |  Skip SSL verification | false |
+| persistence.enabled |  Configure a Persistent Volume as the default storage location. It accepts either a StorageClass name to create a PVC, or directly accepts the PV to use. The Persistent Volume is mounted at `/var/lib/backups` in the operator pod | false |
+| persistence.storageClass |  StorageClass to use for dynamically provisioning the Persistent Volume, which will be used for storing backups | "" |
+| persistence.volumeName |  Persistent Volume to use for storing backups | "" |
+| persistence.size |  Requested size of the Persistent Volume (Applicable when using dynamic provisioning) | "" |
+| nodeSelector | https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector | {} |
+| tolerations | https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration | [] |
+| affinity | https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity | {} |
+
+-----
+
+### CRDs
+
+Refer [this](https://github.com/rancher/backup-restore-operator#crds) section for information on CRDs that this chart installs. Also refer [this](https://github.com/rancher/backup-restore-operator/tree/master/examples) folder containing sample manifests for the CRDs.
+
+-----
+### Upgrading Chart
+```
+helm upgrade rancher-backup-crd -n cattle-resources-system
+helm upgrade rancher-backup -n cattle-resources-system
+```
+
+-----
+### Uninstall Chart
+
+```
+helm uninstall rancher-backup -n cattle-resources-system
+helm uninstall rancher-backup-crd -n cattle-resources-system
+```
+

--- a/charts/rancher-backup/README.md
+++ b/charts/rancher-backup/README.md
@@ -7,7 +7,7 @@ Refer [this](https://github.com/rancher/backup-restore-operator) repository for 
 -----
 
 ### Get Repo Info
-```
+```bash
 helm repo add rancher-chart https://charts.rancher.io
 helm repo update
 ```
@@ -15,7 +15,7 @@ helm repo update
 -----
 
 ### Install Chart
-```
+```bash
 helm install rancher-backup-crd rancher-chart/rancher-backup-crd -n cattle-resources-system --create-namespace
 helm install rancher-backup rancher-chart/rancher-backup -n cattle-resources-system
 ```
@@ -54,7 +54,7 @@ Refer [this](https://github.com/rancher/backup-restore-operator#crds) section fo
 
 -----
 ### Upgrading Chart
-```
+```bash
 helm upgrade rancher-backup-crd -n cattle-resources-system
 helm upgrade rancher-backup -n cattle-resources-system
 ```
@@ -62,7 +62,7 @@ helm upgrade rancher-backup -n cattle-resources-system
 -----
 ### Uninstall Chart
 
-```
+```bash
 helm uninstall rancher-backup -n cattle-resources-system
 helm uninstall rancher-backup-crd -n cattle-resources-system
 ```

--- a/charts/rancher-backup/app-readme.md
+++ b/charts/rancher-backup/app-readme.md
@@ -1,0 +1,15 @@
+# Rancher Backup
+
+This chart enables ability to capture backups of the Rancher application and restore from these backups. This chart can be used to migrate Rancher from one Kubernetes cluster to a different Kubernetes cluster.
+
+For more information on how to use the feature, refer to our [docs](https://rancher.com/docs/rancher/v2.x/en/backups/v2.5/).
+
+This chart installs the following components:
+
+- [backup-restore-operator](https://github.com/rancher/backup-restore-operator)
+  - The operator handles backing up all Kubernetes resources and CRDs that Rancher creates and manages from the local cluster. It gathers these resources by querying the Kubernetes API server, packages all the resources to create a tarball file and saves it in the configured backup storage location.
+  - The operator can be configured to store backups in S3-compatible object stores such as AWS S3 and MinIO, and in persistent volumes. During deployment, you can create a default storage location, but there is always the option to override the default storage location with each backup, but will be limited to using an S3-compatible object store.
+  - It preserves the ownerReferences on all resources, hence maintaining dependencies between objects.
+  - This operator provides encryption support, to encrypt user specified resources before saving them in the backup file. It uses the same encryption configuration that is used to enable [Kubernetes Encryption at Rest](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/).
+- Backup - A backup is a CRD (`Backup`) that defines when to take backups, where to store the backup and what encryption to use (optional). Backups can be taken ad hoc or scheduled to be taken in intervals.
+- Restore - A restore is a CRD (`Restore`) that defines which backup to use to restore the Rancher application to.

--- a/charts/rancher-backup/templates/_helpers.tpl
+++ b/charts/rancher-backup/templates/_helpers.tpl
@@ -1,0 +1,76 @@
+{{- define "system_default_registry" -}}
+{{- if .Values.global.cattle.systemDefaultRegistry -}}
+{{- printf "%s/" .Values.global.cattle.systemDefaultRegistry -}}
+{{- else -}}
+{{- "" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Windows cluster will add default taint for linux nodes, 
+add below linux tolerations to workloads could be scheduled to those linux nodes
+*/}}
+{{- define "linux-node-tolerations" -}}
+- key: "cattle.io/os"
+  value: "linux"
+  effect: "NoSchedule"
+  operator: "Equal"
+{{- end -}}
+
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "backupRestore.fullname" -}}
+{{- .Chart.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "backupRestore.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "backupRestore.labels" -}}
+helm.sh/chart: {{ include "backupRestore.chart" . }}
+{{ include "backupRestore.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "backupRestore.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "backupRestore.fullname" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+resources.cattle.io/operator: backup-restore
+{{- end }}
+
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "backupRestore.serviceAccountName" -}}
+{{ include "backupRestore.fullname" . }}
+{{- end }}
+
+
+{{- define "backupRestore.s3SecretName" -}}
+{{- printf "%s-%s" .Chart.Name "s3" | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create PVC name using release and revision number.
+*/}}
+{{- define "backupRestore.pvcName" -}}
+{{- printf "%s-%d" .Release.Name .Release.Revision }}
+{{- end }}
+

--- a/charts/rancher-backup/templates/clusterrolebinding.yaml
+++ b/charts/rancher-backup/templates/clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "backupRestore.fullname" . }}
+  labels:
+    {{- include "backupRestore.labels" . | nindent 4 }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "backupRestore.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io

--- a/charts/rancher-backup/templates/deployment.yaml
+++ b/charts/rancher-backup/templates/deployment.yaml
@@ -1,0 +1,59 @@
+{{- if and .Values.s3.enabled .Values.persistence.enabled }}
+{{- fail "\n\nCannot configure both s3 and PV for storing backups" }}
+{{- end }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "backupRestore.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "backupRestore.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "backupRestore.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "backupRestore.selectorLabels" . | nindent 8 }}
+      annotations:
+        checksum/s3: {{ include (print $.Template.BasePath "/s3-secret.yaml") . | sha256sum }}
+        checksum/pvc: {{ include (print $.Template.BasePath "/pvc.yaml") . | sha256sum }}
+    spec:
+      serviceAccountName: {{ include "backupRestore.serviceAccountName" . }}
+      containers:
+      - name: {{ .Chart.Name }}
+        image: {{ template "system_default_registry" . }}{{ .Values.image.repository }}:{{ .Values.image.tag }}
+        imagePullPolicy: Always
+        env:
+        - name: CHART_NAMESPACE
+          value: {{ .Release.Namespace }}
+          {{- if .Values.s3.enabled }}
+        - name: DEFAULT_S3_BACKUP_STORAGE_LOCATION
+          value: {{ include "backupRestore.s3SecretName" . }}
+          {{- end }}
+          {{- if .Values.persistence.enabled }}
+        - name: DEFAULT_PERSISTENCE_ENABLED
+          value: "persistence-enabled"
+        volumeMounts:
+        - mountPath: "/var/lib/backups"
+          name: pv-storage
+      volumes:
+        - name: pv-storage
+          persistentVolumeClaim:
+            claimName: {{ include "backupRestore.pvcName" . }}
+          {{- end }} 
+      nodeSelector:
+        kubernetes.io/os: linux
+      {{- with .Values.nodeSelector }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      tolerations:
+      {{- include "linux-node-tolerations" . | nindent 8}}
+      {{- with .Values.tolerations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/rancher-backup/templates/pvc.yaml
+++ b/charts/rancher-backup/templates/pvc.yaml
@@ -1,0 +1,27 @@
+{{- if and .Values.persistence.enabled -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "backupRestore.pvcName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "backupRestore.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+     {{- with .Values.persistence }}
+    requests:
+      storage: {{ .size | quote }}
+{{- if .storageClass }}
+{{- if (eq "-" .storageClass) }}
+  storageClassName: ""
+{{- else }}
+  storageClassName: {{ .storageClass | quote }}
+{{- end }}
+{{- end }}
+{{- if .volumeName }}
+  volumeName: {{ .volumeName | quote }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/rancher-backup/templates/rancher-resourceset.yaml
+++ b/charts/rancher-backup/templates/rancher-resourceset.yaml
@@ -1,0 +1,62 @@
+apiVersion: resources.cattle.io/v1
+kind: ResourceSet
+metadata:
+  name: rancher-resource-set
+resourceSelectors:
+  - apiVersion: "v1"
+    kindsRegexp: "^namespaces$"
+    resourceNameRegexp: "^cattle-|^p-|^c-|^user-|^u-"
+    resourceNames:
+      - "local"
+  - apiVersion: "v1"
+    kindsRegexp: "^secrets$"
+    namespaceRegexp: "^cattle-|^p-|^c-|^local$|^user-|^u-"
+    labelSelectors:
+      matchExpressions:
+        - key: "owner"
+          operator: "NotIn"
+          values: ["helm"]
+  - apiVersion: "v1"
+    kindsRegexp: "^serviceaccounts$"
+    namespaceRegexp: "^cattle-|^p-|^c-|^local$|^user-|^u-"
+  - apiVersion: "v1"
+    kindsRegexp: "^configmaps$"
+    namespaces:
+      - "cattle-system"
+  - apiVersion: "rbac.authorization.k8s.io/v1"
+    kindsRegexp: "^roles$|^rolebindings$"
+    namespaceRegexp: "^cattle-|^p-|^c-|^local$|^user-|^u-"
+  - apiVersion: "rbac.authorization.k8s.io/v1"
+    kindsRegexp: "^clusterrolebindings$"
+    resourceNameRegexp: "^cattle-|^clusterrolebinding-|^globaladmin-user-|^grb-u-"
+    resourceNames:
+      - "eks-operator"
+  - apiVersion: "rbac.authorization.k8s.io/v1"
+    kindsRegexp: "^clusterroles$"
+    resourceNameRegexp: "^cattle-|^p-|^c-|^local-|^user-|^u-|^project-|^create-ns$"
+    resourceNames:
+      - "eks-operator"
+  - apiVersion: "apiextensions.k8s.io/v1beta1"
+    kindsRegexp: "."
+    resourceNameRegexp: "management.cattle.io$|project.cattle.io$|catalog.cattle.io$|eks.cattle.io$|resources.cattle.io$"
+  - apiVersion: "management.cattle.io/v3"
+    kindsRegexp: "."
+  - apiVersion: "project.cattle.io/v3"
+    kindsRegexp: "."
+  - apiVersion: "catalog.cattle.io/v1"
+    kindsRegexp: "^clusterrepos$"
+  - apiVersion: "resources.cattle.io/v1"
+    kindsRegexp: "^ResourceSet$"
+  - apiVersion: "eks.cattle.io/v1"
+    kindsRegexp: "."
+  - apiVersion: "apps/v1"
+    kindsRegexp: "^deployments$"
+    resourceNames:
+      - "eks-config-operator"
+    namespaces:
+      - "cattle-system"
+controllerReferences:
+  - apiVersion: "apps/v1"
+    resource: "deployments"
+    name: "rancher"
+    namespace: "cattle-system"

--- a/charts/rancher-backup/templates/s3-secret.yaml
+++ b/charts/rancher-backup/templates/s3-secret.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.s3.enabled -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "backupRestore.s3SecretName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "backupRestore.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{- with .Values.s3 }}
+  {{- if .credentialSecretName }}
+  credentialSecretName: {{ .credentialSecretName }} 
+  credentialSecretNamespace: {{ required "When providing a Secret containing S3 credentials, a valid .Values.credentialSecretNamespace must be provided" .credentialSecretNamespace }}
+  {{- end }}
+  {{- if .region }}
+  region: {{ .region }}
+  {{- end }}
+  bucketName: {{ required "A valid .Values.bucketName is required for configuring S3 compatible storage as the default backup storage location" .bucketName }}
+  {{- if .folder }}
+  folder: {{ .folder }} 
+  {{- end }}
+  endpoint: {{ required "A valid .Values.endpoint is required for configuring S3 compatible storage as the default backup storage location" .endpoint }}
+  {{- if .endpointCA }} 
+  endpointCA: {{ .endpointCA }} 
+  {{- end }}
+  {{- if .insecureTLSSkipVerify }}
+  insecureTLSSkipVerify: {{ .insecureTLSSkipVerify | quote }}
+  {{- end }}
+  {{- end }}
+{{ end }}

--- a/charts/rancher-backup/templates/serviceaccount.yaml
+++ b/charts/rancher-backup/templates/serviceaccount.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "backupRestore.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "backupRestore.labels" . | nindent 4 }}

--- a/charts/rancher-backup/templates/validate-install-crd.yaml
+++ b/charts/rancher-backup/templates/validate-install-crd.yaml
@@ -1,0 +1,16 @@
+#{{- if gt (len (lookup "rbac.authorization.k8s.io/v1" "ClusterRole" "" "")) 0 -}}
+# {{- $found := dict -}}
+# {{- set $found "resources.cattle.io/v1/Backup" false -}}
+# {{- set $found "resources.cattle.io/v1/ResourceSet" false -}}
+# {{- set $found "resources.cattle.io/v1/Restore" false -}}
+# {{- range .Capabilities.APIVersions -}}
+# {{- if hasKey $found (toString .) -}}
+# 	{{- set $found (toString .) true -}}
+# {{- end -}}
+# {{- end -}}
+# {{- range $_, $exists := $found -}}
+# {{- if (eq $exists false) -}}
+# 	{{- required "Required CRDs are missing. Please install the corresponding CRD chart before installing this chart." "" -}}
+# {{- end -}}
+# {{- end -}}
+#{{- end -}}

--- a/charts/rancher-backup/values.yaml
+++ b/charts/rancher-backup/values.yaml
@@ -1,0 +1,49 @@
+image:
+  repository: rancher/backup-restore-operator
+  tag: v1.0.3
+
+## Default s3 bucket for storing all backup files created by the backup-restore-operator
+s3:
+  enabled: false
+  ## credentialSecretName if set, should be the name of the Secret containing AWS credentials.
+  ## To use IAM Role, don't set this field
+  credentialSecretName: ""
+  credentialSecretNamespace: ""
+  region: ""
+  bucketName: ""
+  folder: ""
+  endpoint: ""
+  endpointCA: ""
+  insecureTLSSkipVerify: false
+
+## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+## If persistence is enabled, operator will create a PVC with mountPath /var/lib/backups
+persistence: 
+  enabled: false
+
+  ## If defined, storageClassName: <storageClass>
+  ## If set to "-", storageClassName: "", which disables dynamic provisioning
+  ## If undefined (the default) or set to null, no storageClassName spec is
+  ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+  ##   GKE, AWS & OpenStack). 
+  ## Refer https://kubernetes.io/docs/concepts/storage/persistent-volumes/#class-1
+  ##
+  storageClass: "-"
+
+  ## If you want to disable dynamic provisioning by setting storageClass to "-" above, 
+  ## and want to target a particular PV, provide name of the target volume 
+  volumeName: ""
+
+  ## Only certain StorageClasses allow resizing PVs; Refer https://kubernetes.io/blog/2018/07/12/resizing-persistent-volumes-using-kubernetes/
+  size: 2Gi
+
+
+global:
+  cattle:
+    systemDefaultRegistry: ""
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/scripts/package
+++ b/scripts/package
@@ -16,3 +16,5 @@ fi
 
 docker build -f ${DOCKERFILE} -t ${IMAGE} .
 echo Built ${IMAGE}
+
+./scripts/package-helm

--- a/scripts/package-helm
+++ b/scripts/package-helm
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -e
+
+if ! hash helm 2>/dev/null; then
+    exit 0
+fi
+
+cd $(dirname $0)/..
+. ./scripts/version
+
+rm -rf build/charts
+mkdir -p build dist/artifacts
+cp -rf charts build/
+
+sed -i \
+    -e 's/version:.*/version: '${HELM_VERSION}'/' \
+    -e 's/appVersion:.*/appVersion: '${HELM_VERSION}'/' \
+    build/charts/rancher-backup/Chart.yaml
+
+sed -i \
+    -e 's/tag:.*/tag: '${HELM_TAG}'/' \
+    build/charts/rancher-backup/values.yaml
+
+sed -i \
+    -e 's/version:.*/version: '${HELM_VERSION}'/' \
+    -e 's/appVersion:.*/appVersion: '${HELM_VERSION}'/' \
+    build/charts/rancher-backup-crd/Chart.yaml
+
+helm package -d ./dist/artifacts ./build/charts/rancher-backup
+helm package -d ./dist/artifacts ./build/charts/rancher-backup-crd


### PR DESCRIPTION
This PR is split into **three** commits and may be easily "reviewable" by reviewing commit by commit. It follows the [rancher/rancher-operator](https://github.com/rancher/rancher-operator) charts pattern.

1. Copy chart from [rancher/charts](https://github.com/rancher/charts)
2. Add helm packaging and prepare the chart for packing

Note: we are _not_ merging the old ResourceSet file yet.

Relevant issues:
- https://github.com/rancher/tasks/issues/172
- https://github.com/rancher/backup-restore-operator/issues/78
- https://github.com/rancher/backup-restore-operator/issues/69 (while indirectly related, some resources were added to this repository's CR file, rather than the one in [rancher/charts](https://github.com/rancher/charts))