### PR TITLE
add new name regexp for clusterrolebinding for Rancher

### DIFF
--- a/charts/rancher-backup/files/default-resourceset-contents/rancher.yaml
+++ b/charts/rancher-backup/files/default-resourceset-contents/rancher.yaml
@@ -27,7 +27,7 @@
   namespaceRegexp: "^cattle-|^p-|^c-|^local$|^user-|^u-"
 - apiVersion: "rbac.authorization.k8s.io/v1"
   kindsRegexp: "^clusterrolebindings$"
-  resourceNameRegexp: "^cattle-|^clusterrolebinding-|^globaladmin-user-|^grb-u-"
+  resourceNameRegexp: "^cattle-|^clusterrolebinding-|^globaladmin-user-|^grb-u-|^crb-"
 - apiVersion: "rbac.authorization.k8s.io/v1"
   kindsRegexp: "^clusterroles$"
   resourceNameRegexp: "^cattle-|^p-|^c-|^local-|^user-|^u-|^project-|^create-ns$"


### PR DESCRIPTION
issue: https://github.com/rancher/backup-restore-operator/issues/95


New clusterRoleBinding will be named [crb-*](https://github.com/rancher/rancher/blob/1c3629fbe520d4cfe66b95c31cfdd2f3946f39dc/pkg/rbac/common.go#L179) 
New roleBinding will be named [rb-*](https://github.com/rancher/rancher/blob/1c3629fbe520d4cfe66b95c31cfdd2f3946f39dc/pkg/rbac/common.go#L169)  

We need to add the new clusterRoleBinding to the resourceSet.

The new roleBinding is already covered by the existing resourceSet which matches namespaces:
https://github.com/rancher/backup-restore-operator/blob/f64bef3ed6200dd781860d8dd6b4ccdc2ce1ea26/charts/rancher-backup/files/default-resourceset-contents/rancher.yaml#L25-L27