### PR TITLE
add support for installing the app into a hardened cluster

### DIFF
--- a/charts/rancher-backup/templates/_helpers.tpl
+++ b/charts/rancher-backup/templates/_helpers.tpl
@@ -17,6 +17,13 @@ add below linux tolerations to workloads could be scheduled to those linux nodes
   operator: "Equal"
 {{- end -}}
 
+{{- define "linux-node-selector" -}}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+beta.kubernetes.io/os: linux
+{{- else -}}
+kubernetes.io/os: linux
+{{- end -}}
+{{- end -}}
 
 {{/*
 Create a default fully qualified app name.

--- a/charts/rancher-backup/templates/hardened.yaml
+++ b/charts/rancher-backup/templates/hardened.yaml
@@ -1,0 +1,116 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "backupRestore.fullname" . }}-patch-sa
+  namespace: {{ .Release.Namespace }}
+  labels: {{ include "backupRestore.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install, post-upgrade
+    "helm.sh/hook-delete-policy": hook-succeeded, before-hook-creation
+spec:
+  backoffLimit: 1
+  template:
+    spec:
+      serviceAccountName: {{ include "backupRestore.fullname" . }}-patch-sa
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+      restartPolicy: Never
+      nodeSelector: {{ include "linux-node-selector" . | nindent 8 }}
+      tolerations: {{ include "linux-node-tolerations" . | nindent 8 }}
+      containers:
+        - name: {{ include "backupRestore.fullname" . }}-patch-sa
+          image: {{ include "system_default_registry" . }}{{ .Values.global.kubectl.repository }}:{{ .Values.global.kubectl.tag }}
+          imagePullPolicy: IfNotPresent
+          command: ["kubectl", "-n", {{ .Release.Namespace | quote }}, "patch", "serviceaccount", "default", "-p", "{\"automountServiceAccountToken\": false}"]
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "backupRestore.fullname" . }}-patch-sa
+  namespace: {{ .Release.Namespace }}
+  labels: {{ include "backupRestore.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install, post-upgrade
+    "helm.sh/hook-delete-policy": hook-succeeded, before-hook-creation
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "backupRestore.fullname" . }}-patch-sa
+  labels: {{ include "backupRestore.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install, post-upgrade
+    "helm.sh/hook-delete-policy": hook-succeeded, before-hook-creation
+rules:
+  - apiGroups: [""]
+    resources: ["serviceaccounts"]
+    verbs: ["get", "patch"]
+  - apiGroups: ["policy"]
+    resources: ["podsecuritypolicies"]
+    verbs:     ["use"]
+    resourceNames:
+      - {{ include "backupRestore.fullname" . }}-patch-sa
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "backupRestore.fullname" . }}-patch-sa
+  labels: {{ include "backupRestore.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install, post-upgrade
+    "helm.sh/hook-delete-policy": hook-succeeded, before-hook-creation
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "backupRestore.fullname" . }}-patch-sa
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "backupRestore.fullname" . }}-patch-sa
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ include "backupRestore.fullname" . }}-patch-sa
+  labels: {{ include "backupRestore.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install, post-upgrade
+    "helm.sh/hook-delete-policy": hook-succeeded, before-hook-creation
+spec:
+  privileged: false
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'MustRunAsNonRoot'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  readOnlyRootFilesystem: false
+  volumes:
+    - 'secret'
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "backupRestore.fullname" . }}-default-allow-all
+  namespace: {{ .Release.Namespace }}
+spec:
+  podSelector: {}
+  ingress:
+    - {}
+  egress:
+    - {}
+  policyTypes:
+    - Ingress
+    - Egress

--- a/charts/rancher-backup/templates/psp.yaml
+++ b/charts/rancher-backup/templates/psp.yaml
@@ -1,0 +1,29 @@
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ include "backupRestore.fullname" . }}-psp
+  labels: {{ include "backupRestore.labels" . | nindent 4 }}
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'MustRunAsNonRoot'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  readOnlyRootFilesystem: false
+  volumes:
+    - 'persistentVolumeClaim'
+    - 'secret'

--- a/charts/rancher-backup/values.yaml
+++ b/charts/rancher-backup/values.yaml
@@ -41,6 +41,9 @@ persistence:
 global:
   cattle:
     systemDefaultRegistry: ""
+  kubectl:
+    repository: rancher/kubectl
+    tag: v1.20.2
 
 nodeSelector: {}
 


### PR DESCRIPTION
Issues: 
https://github.com/rancher/backup-restore-operator/issues/29
https://github.com/rancher/backup-restore-operator/issues/34


- The chart is tested on a custom hardened cluster under the [CIS 1.6 Benchmark](https://rancher.com/docs/rancher/v2.x/en/security/rancher-2.5/1.6-hardening-2.5/). 
- The app is installed into the hardened cluster successfully.
- After the app is installed, pass the CIS scan with the profile `rke-profile-hardened-1.6`


Next Steps **(after release v2.5.8)** :
- [ ] cut an RC in this repo
- [ ] submit a PR in rancher/chart to cut an RC for the chart 