### PR TITLE
Fix: annotations for service account template

### DIFF
--- a/charts/rancher-backup/templates/serviceaccount.yaml
+++ b/charts/rancher-backup/templates/serviceaccount.yaml
@@ -6,6 +6,6 @@ metadata:
   labels:
      {{- include "backupRestore.labels" . | nindent 4 }}
 {{- if .Values.serviceAccount.annotations }}
-   annotations:
-     {{- toYaml .Values.serviceAccount.annotations | nindent 4 }}
+  annotations:
+    {{- toYaml .Values.serviceAccount.annotations | nindent 4 }}
 {{- end }}


### PR DESCRIPTION
As of current version v1.1.1 using custom annotations for serviceAccount, chart will fail with:
Error: YAML parse error on rancher-backup/templates/serviceaccount.yaml: error converting YAML to JSON: y
aml: line 12: did not find expected key => caused by bad annotations ident(1 space extra, should be inline with labes).