### PR TITLE
block all ingress traffic

### DIFF
--- a/charts/rancher-backup/templates/hardened.yaml
+++ b/charts/rancher-backup/templates/hardened.yaml
@@ -107,8 +107,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   podSelector: {}
-  ingress:
-    - {}
   egress:
     - {}
   policyTypes:


### PR DESCRIPTION
issue: https://github.com/rancher/backup-restore-operator/issues/116

reference: https://kubernetes.io/docs/concepts/services-networking/network-policies/#default-deny-all-ingress-traffic

This PR is tested and confirmed working on a hardened cluster. 