### PR TITLE
only replace the image tag for rancher/backup-restore-operator

### DIFF
--- a/charts/rancher-backup/values.yaml
+++ b/charts/rancher-backup/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: rancher/backup-restore-operator
-  tag: v1.0.3
+  tag: %TAG%
 
 ## Default s3 bucket for storing all backup files created by the backup-restore-operator
 s3:

--- a/scripts/package-helm
+++ b/scripts/package-helm
@@ -8,7 +8,7 @@ function edit-charts() {
         build/charts/rancher-backup/Chart.yaml
 
     sed -i \
-        -e 's/tag:.*/tag: '${2}'/' \
+        -e 's/%TAG%/'${2}'/' \
         build/charts/rancher-backup/values.yaml
 
     sed -i \


### PR DESCRIPTION
related issue: https://github.com/rancher/backup-restore-operator/issues/34

We added the image to the value.yaml as part of supporting installation in the hardened cluster, and the image tag of rancher/kube	ctl should not be replaced by the chart version when generating the chart. 

https://github.com/rancher/backup-restore-operator/blob/66a7054f2dfe7ec9e39f4a33f6a485ec266eae1f/charts/rancher-backup/values.yaml#L44-L46