### PR TITLE
remove the trailing slash from the folder name

### DIFF
--- a/pkg/controllers/restore/download.go
+++ b/pkg/controllers/restore/download.go
@@ -29,7 +29,8 @@ func (h *handler) downloadFromS3(restore *v1.Restore, objStore *v1.S3ObjectStore
 	}
 	folder := objStore.Folder
 	if len(folder) != 0 {
-		prefix = fmt.Sprintf("%s/%s", folder, prefix)
+		// remove the trailing / from the folder name
+		prefix = fmt.Sprintf("%s/%s", strings.TrimSuffix(folder, "/"), prefix)
 	}
 	targetFileLocation, err := objectstore.DownloadFromS3WithPrefix(s3Client, prefix, objStore.BucketName)
 	if err != nil {


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/33734

Problem:
If the value of the `folder name` contains trailing slash `/`, the full path to the backup file in S3 will have double slashes in it, which leads to the `no backups found` error 

Fix:
Trim the trailing slash from the value. 


Next Step:

- [ ] cut a new tag 
- [ ] update the rancher-backup chart 