### PR TITLE
Add cluster-tool chart annotation

### DIFF
--- a/charts/rancher-backup/Chart.yaml
+++ b/charts/rancher-backup/Chart.yaml
@@ -12,6 +12,7 @@ annotations:
   catalog.cattle.io/auto-install: rancher-backup-crd=match
   catalog.cattle.io/certified: rancher
   catalog.cattle.io/display-name: Rancher Backups
+  catalog.cattle.io/type: cluster-tool
   catalog.cattle.io/namespace: cattle-resources-system
   catalog.cattle.io/os: linux
   catalog.cattle.io/provides-gvr: resources.cattle.io.resourceset/v1


### PR DESCRIPTION
**Issue**
https://github.com/rancher/rancher/issues/33841

**Problem**
new Cluster Tools page needs a way to display specific charts.

**Solution**
Add a new chart annotation that can be used to determine what charts should be displayed: catalog.cattle.io/type=cluster-tool

