### PR TITLE
Fix for setting backup and restore status

### DIFF
--- a/pkg/apis/resources.cattle.io/v1/types.go
+++ b/pkg/apis/resources.cattle.io/v1/types.go
@@ -37,13 +37,13 @@ type BackupSpec struct {
 
 type BackupStatus struct {
 	Conditions         []genericcondition.GenericCondition `json:"conditions"`
-	LastSnapshotTS     string                              `json:"lastSnapshotTs"`
-	NextSnapshotAt     string                              `json:"nextSnapshotAt"`
-	ObservedGeneration int64                               `json:"observedGeneration"`
-	StorageLocation    string                              `json:"storageLocation"`
-	BackupType         string                              `json:"backupType"`
-	Filename           string                              `json:"filename"`
-	Summary            string                              `json:"summary"`
+	LastSnapshotTS     string                              `json:"lastSnapshotTs,omitempty"`
+	NextSnapshotAt     string                              `json:"nextSnapshotAt,omitempty"`
+	ObservedGeneration int64                               `json:"observedGeneration,omitempty"`
+	StorageLocation    string                              `json:"storageLocation,omitempty"`
+	BackupType         string                              `json:"backupType,omitempty"`
+	Filename           string                              `json:"filename,omitempty"`
+	Summary            string                              `json:"summary,omitempty"`
 }
 
 // +genclient
@@ -115,8 +115,8 @@ type RestoreSpec struct {
 
 type RestoreStatus struct {
 	Conditions          []genericcondition.GenericCondition `json:"conditions,omitempty"`
-	RestoreCompletionTS string                              `json:"restoreCompletionTs"`
-	ObservedGeneration  int64                               `json:"observedGeneration"`
-	BackupSource        string                              `json:"backupSource"`
-	Summary             string                              `json:"summary"`
+	RestoreCompletionTS string                              `json:"restoreCompletionTs,omitempty"`
+	ObservedGeneration  int64                               `json:"observedGeneration,omitempty"`
+	BackupSource        string                              `json:"backupSource,omitempty"`
+	Summary             string                              `json:"summary,omitempty"`
 }


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/33946
and
https://github.com/rancher/rancher/issues/33942

For restore object, just needed to add `omitempty`. Tested by running local against `v1.20.9+rke2r1` setup provided by Jan Bruder who reported the issue.
Note missing `omitempty` on `ObservedGeneration` doesn't cause any failures, but having it set to 0 is rather unsightly so I've updated it too.

As far as backup object goes, if there is a failure none of direct Status fields are set, so all of them got `omitempty` added.

TODO after the PR is merged:
- [ ] Cut a new tag
- [ ] Update chart in rancher/charts