### PR TITLE
remove the deployment in ns cattle-system from the resourceSet

### DIFF
--- a/charts/rancher-backup/files/default-resourceset-contents/rancher.yaml
+++ b/charts/rancher-backup/files/default-resourceset-contents/rancher.yaml
@@ -3,10 +3,6 @@
   resourceNameRegexp: "^cattle-|^p-|^c-|^user-|^u-"
   resourceNames:
     - "local"
-- apiVersion: "apps/v1"
-  kindsRegexp: "^deployments$"
-  namespaces:
-    - "cattle-system"
 - apiVersion: "v1"
   kindsRegexp: "^secrets$"
   namespaceRegexp: "^cattle-|^p-|^c-|^local$|^user-|^u-"

--- a/pkg/controllers/restore/controller.go
+++ b/pkg/controllers/restore/controller.go
@@ -356,10 +356,15 @@ func (h *handler) generateDependencyGraph(ownerToDependentsList map[string][]res
 		resourceInfoToData = objFromBackupCR.namespacedResourceInfoToData
 	}
 	for resourceInfo, resourceData := range resourceInfoToData {
-		// add to adjacency list
 		name := resourceInfo.Name
 		namespace := resourceInfo.Namespace
 		gvr := resourceInfo.GVR
+		if resourceData.GetKind() == "Deployment" && namespace == "cattle-system" {
+			if strings.HasSuffix(name, "rancher") || strings.HasSuffix(name, "rancher-webhook") {
+				logrus.Infof("Skip restoring the deployment %s/%s", namespace, name)
+				continue
+			}
+		}
 		// TODO: Maybe restoreObj won't be needed
 		currRestoreObj := restoreObj{
 			Name:               name,


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/34247

Fixes:     
- remove deployment in  ns `cattle-system` from the ResourceSet, so a new backup does not include rancher and rancher-webhook
- skip the deployment rancher and rancher-webhook when restoring


With the fixies, we can get the following results:

 


 If deployment rancher is in the backup | migrate to a new cluster (no rancher exists)  | restore in the same cluster (rancher exists) | rollback in the same cluster ( upgraded rancher exists)
-- | -- | -- | --
yes | no rancher | existing rancher runs up | existing rancher 2.6.0 runs up *can be fixed by new steps
no  | no rancher | existing rancher runs up | existing rancher 2.6.0 runs up *can be fixed by new steps
 
The case of `rollback in the same cluster ( upgraded rancher exists)` is based on this scenario:
```
- install Rancher v2.5.9 into the cluster
- make a backup
- upgrade rancher to 2.6.0
- rollback to 2.5.9 by restoring the backup
```

The above 2 cases with * can be solved by following the new steps for rolling back rancher
```
- scale the deployment rancher to 0 
- - restore the backup file
- run `helm rollback rancher -n cattle-system` to run rancher 2.5.9 up 
```
A separate issue for updating the documentation is made: https://github.com/rancher/docs/issues/3460


TODO after mering:
- [] back port to the 2.5 line