### PR TITLE
Do not store kubeconfig token, add machine secret

### DIFF
--- a/charts/rancher-backup-crd/templates/resourceset.yaml
+++ b/charts/rancher-backup-crd/templates/resourceset.yaml
@@ -34,6 +34,11 @@ spec:
             properties:
               apiVersion:
                 type: string
+              excludeKinds:
+                items:
+                  type: string
+                nullable: true
+                type: array
               kinds:
                 items:
                   type: string

--- a/charts/rancher-backup/files/default-resourceset-contents/provisioningv2.yaml
+++ b/charts/rancher-backup/files/default-resourceset-contents/provisioningv2.yaml
@@ -13,6 +13,6 @@
   kindsRegexp: "."
 - apiVersion: "v1"
   kindsRegexp: "^secrets$"
-  resourceNameRegexp: "machine-plan$|rke-state$"
+  resourceNameRegexp: "machine-plan$|rke-state$|machine-state$|machine-driver-secret$|machine-provision$"
   namespaces:
   - "fleet-default"

--- a/charts/rancher-backup/files/default-resourceset-contents/rancher.yaml
+++ b/charts/rancher-backup/files/default-resourceset-contents/rancher.yaml
@@ -36,6 +36,15 @@
   resourceNameRegexp: "management.cattle.io$|project.cattle.io$|catalog.cattle.io$|resources.cattle.io$"
 - apiVersion: "management.cattle.io/v3"
   kindsRegexp: "."
+  excludeKinds:
+    - "tokens"
+- apiVersion: "management.cattle.io/v3"
+  kindsRegexp: "^tokens$"
+  labelSelectors:
+    matchExpressions:
+      - key: "authn.management.cattle.io/kind"
+        operator: "NotIn"
+        values: [ "provisioning" ]
 - apiVersion: "project.cattle.io/v3"
   kindsRegexp: "."
 - apiVersion: "catalog.cattle.io/v1"

--- a/pkg/apis/resources.cattle.io/v1/types.go
+++ b/pkg/apis/resources.cattle.io/v1/types.go
@@ -68,6 +68,7 @@ type ResourceSelector struct {
 	Namespaces         []string              `json:"namespaces,omitempty"`
 	NamespaceRegexp    string                `json:"namespaceRegexp,omitempty"`
 	LabelSelectors     *metav1.LabelSelector `json:"labelSelectors,omitempty"`
+	ExcludeKinds       []string              `json:"excludeKinds,omitempty"`
 }
 
 type ControllerReference struct {

--- a/pkg/apis/resources.cattle.io/v1/zz_generated_deepcopy.go
+++ b/pkg/apis/resources.cattle.io/v1/zz_generated_deepcopy.go
@@ -168,6 +168,11 @@ func (in *ResourceSelector) DeepCopyInto(out *ResourceSelector) {
 		*out = new(metav1.LabelSelector)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.ExcludeKinds != nil {
+		in, out := &in.ExcludeKinds, &out.ExcludeKinds
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/33954

Context: https://github.com/rancher/rancher/issues/33954#issuecomment-903001616

TLDR: we shouldn't be restoring token associated with kubeconfig secret, as it is cached by secret and we can't restore secret too because it has rancher service IP which could change during restore. Also add machine secret so that during a restore ssh and download keys are still available for machine nodes.