### PR TITLE
New way to handle subResource Status 

### DIFF
--- a/pkg/controllers/backup/controller.go
+++ b/pkg/controllers/backup/controller.go
@@ -237,7 +237,7 @@ func (h *handler) performBackup(backup *v1.Backup, tmpBackupPath, backupFileName
 		DynamicClient:   h.dynamicClient,
 		TransformerMap:  transformerMap,
 	}
-	resourcesWithStatusSubresource, err := rh.GatherResources(h.ctx, resourceSetTemplate.ResourceSelectors)
+	err = rh.GatherResources(h.ctx, resourceSetTemplate.ResourceSelectors)
 	if err != nil {
 		return err
 	}
@@ -259,17 +259,6 @@ func (h *handler) performBackup(backup *v1.Backup, tmpBackupPath, backupFileName
 		return err
 	}
 	err = ioutil.WriteFile(filepath.Join(filtersPath, "filters.json"), filters, os.ModePerm)
-	if err != nil {
-		return err
-	}
-
-	logrus.Infof("Saving information about resources with status subresource that are part of backup CR %v", backup.Name)
-	subresources, err := json.Marshal(resourcesWithStatusSubresource)
-	if err != nil {
-		return err
-
-	}
-	err = ioutil.WriteFile(filepath.Join(filtersPath, "statussubresource.json"), subresources, os.ModePerm)
 	if err != nil {
 		return err
 	}

--- a/pkg/controllers/restore/controller.go
+++ b/pkg/controllers/restore/controller.go
@@ -16,6 +16,7 @@ import (
 	v1core "github.com/rancher/wrangler-api/pkg/generated/controllers/core/v1"
 	"github.com/rancher/wrangler/pkg/condition"
 	"github.com/rancher/wrangler/pkg/genericcondition"
+	"github.com/rancher/wrangler/pkg/slice"
 	"github.com/sirupsen/logrus"
 
 	coordinationv1 "k8s.io/api/coordination/v1"
@@ -36,12 +37,14 @@ import (
 )
 
 const (
-	metadataMapKey  = "metadata"
-	ownerRefsMapKey = "ownerReferences"
-	clusterScoped   = "clusterscoped"
-	namespaceScoped = "namespaceScoped"
-	leaseName       = "restore-controller"
-	secretsMapKey   = "secrets"
+	metadataMapKey     = "metadata"
+	ownerRefsMapKey    = "ownerReferences"
+	clusterScoped      = "clusterscoped"
+	namespaceScoped    = "namespaceScoped"
+	leaseName          = "restore-controller"
+	secretsMapKey      = "secrets"
+	specMapKey         = "spec"
+	subResourcesMapKey = "subresources"
 )
 
 type handler struct {
@@ -64,7 +67,6 @@ type ObjectsFromBackupCR struct {
 	clusterscopedResourceInfoToData map[objInfo]unstructured.Unstructured
 	namespacedResourceInfoToData    map[objInfo]unstructured.Unstructured
 	resourcesFromBackup             map[string]bool
-	resourcesWithStatusSubresource  map[string]bool
 	backupResourceSet               v1.ResourceSet
 }
 
@@ -140,6 +142,7 @@ func (h *handler) OnRestoreChange(_ string, restore *v1.Restore) (*v1.Restore, e
 
 	created := make(map[string]bool)
 	ownerToDependentsList := make(map[string][]restoreObj)
+	var crdsWithSubStatus []string
 	var toRestore []restoreObj
 	numOwnerReferences := make(map[string]int)
 	objFromBackupCR := ObjectsFromBackupCR{
@@ -147,7 +150,6 @@ func (h *handler) OnRestoreChange(_ string, restore *v1.Restore) (*v1.Restore, e
 		clusterscopedResourceInfoToData: make(map[objInfo]unstructured.Unstructured),
 		namespacedResourceInfoToData:    make(map[objInfo]unstructured.Unstructured),
 		resourcesFromBackup:             make(map[string]bool),
-		resourcesWithStatusSubresource:  make(map[string]bool),
 		backupResourceSet:               v1.ResourceSet{},
 	}
 
@@ -213,7 +215,7 @@ func (h *handler) OnRestoreChange(_ string, restore *v1.Restore) (*v1.Restore, e
 
 	// first restore CRDs
 	logrus.Infof("Starting to restore CRDs for restore CR %v", restore.Name)
-	if err := h.restoreCRDs(created, objFromBackupCR); err != nil {
+	if crdsWithSubStatus, err = h.restoreCRDs(created, objFromBackupCR); err != nil {
 		h.scaleUpControllersFromResourceSet(objFromBackupCR)
 		logrus.Errorf("Error restoring CRDs %v", err)
 		// Cannot set the exact error on reconcile condition, the order in which resources failed to restore are added in err msg could
@@ -223,7 +225,7 @@ func (h *handler) OnRestoreChange(_ string, restore *v1.Restore) (*v1.Restore, e
 
 	logrus.Infof("Starting to restore clusterscoped resources for restore CR %v", restore.Name)
 	// then restore clusterscoped resources, by first generating dependency graph for cluster scoped resources, and create from the graph
-	if err := h.restoreClusterScopedResources(ownerToDependentsList, &toRestore, numOwnerReferences, created, objFromBackupCR); err != nil {
+	if err := h.restoreClusterScopedResources(ownerToDependentsList, &toRestore, numOwnerReferences, created, objFromBackupCR, crdsWithSubStatus); err != nil {
 		h.scaleUpControllersFromResourceSet(objFromBackupCR)
 		logrus.Errorf("Error restoring cluster-scoped resources %v", err)
 		return h.setReconcilingCondition(restore, fmt.Errorf("error restoring cluster-scoped resources, check logs for exact error"))
@@ -233,7 +235,7 @@ func (h *handler) OnRestoreChange(_ string, restore *v1.Restore) (*v1.Restore, e
 	// now restore namespaced resources: generate adjacency lists for dependents and ownerRefs for namespaced resources
 	ownerToDependentsList = make(map[string][]restoreObj)
 	toRestore = []restoreObj{}
-	if err := h.restoreNamespacedResources(ownerToDependentsList, &toRestore, numOwnerReferences, created, objFromBackupCR); err != nil {
+	if err := h.restoreNamespacedResources(ownerToDependentsList, &toRestore, numOwnerReferences, created, objFromBackupCR, crdsWithSubStatus); err != nil {
 		h.scaleUpControllersFromResourceSet(objFromBackupCR)
 		logrus.Errorf("Error restoring namespaced resources %v", err)
 		return h.setReconcilingCondition(restore, fmt.Errorf("error restoring namespaced resources, check logs for exact error"))
@@ -273,20 +275,32 @@ func (h *handler) OnRestoreChange(_ string, restore *v1.Restore) (*v1.Restore, e
 	return restore, err
 }
 
-func (h *handler) restoreCRDs(created map[string]bool, objFromBackupCR ObjectsFromBackupCR) error {
+func (h *handler) restoreCRDs(created map[string]bool, objFromBackupCR ObjectsFromBackupCR) (crdsWithSubStatus []string, err error) {
 	for crdInfo, crdData := range objFromBackupCR.crdInfoToData {
 		err := h.restoreResource(crdInfo, crdData, false)
 		if err != nil {
-			return fmt.Errorf("restoreCRDs: %v", err)
+			return crdsWithSubStatus, fmt.Errorf("restoreCRDs: %v", err)
 		}
 		created[crdInfo.ConfigPath] = true
+
+		specs := crdData.Object[specMapKey].(map[string]interface{})
+		subResources, ok := specs[subResourcesMapKey]
+		if ok {
+			for k := range subResources.(map[string]interface{}) {
+				if k == "status" {
+					// example: groupVersion = clusterrepos.catalog.cattle.io/v1
+					groupVersion := fmt.Sprintf("%s/%s", crdInfo.Name, specs["version"])
+					crdsWithSubStatus = append(crdsWithSubStatus, groupVersion)
+				}
+			}
+		}
 	}
 	for crdInfo := range objFromBackupCR.crdInfoToData {
 		if err := h.waitCRD(crdInfo.Name); err != nil {
-			return err
+			return crdsWithSubStatus, err
 		}
 	}
-	return nil
+	return crdsWithSubStatus, nil
 }
 
 func (h *handler) waitCRD(crdName string) error {
@@ -321,21 +335,21 @@ func (h *handler) waitCRD(crdName string) error {
 }
 
 func (h *handler) restoreClusterScopedResources(ownerToDependentsList map[string][]restoreObj, toRestore *[]restoreObj,
-	numOwnerReferences map[string]int, created map[string]bool, objFromBackupCR ObjectsFromBackupCR) error {
+	numOwnerReferences map[string]int, created map[string]bool, objFromBackupCR ObjectsFromBackupCR, crdsWithSubStatus []string) error {
 	// generate adjacency lists for dependents and ownerRefs first for clusterscoped resources
 	if err := h.generateDependencyGraph(ownerToDependentsList, toRestore, numOwnerReferences, objFromBackupCR, created, clusterScoped); err != nil {
 		return err
 	}
-	return h.createFromDependencyGraph(ownerToDependentsList, created, numOwnerReferences, objFromBackupCR, *toRestore)
+	return h.createFromDependencyGraph(ownerToDependentsList, created, numOwnerReferences, objFromBackupCR, *toRestore, crdsWithSubStatus)
 }
 
 func (h *handler) restoreNamespacedResources(ownerToDependentsList map[string][]restoreObj, toRestore *[]restoreObj,
-	numOwnerReferences map[string]int, created map[string]bool, objFromBackupCR ObjectsFromBackupCR) error {
+	numOwnerReferences map[string]int, created map[string]bool, objFromBackupCR ObjectsFromBackupCR, crdsWithSubStatus []string) error {
 	// generate adjacency lists for dependents and ownerRefs for namespaced resources
 	if err := h.generateDependencyGraph(ownerToDependentsList, toRestore, numOwnerReferences, objFromBackupCR, created, namespaceScoped); err != nil {
 		return err
 	}
-	return h.createFromDependencyGraph(ownerToDependentsList, created, numOwnerReferences, objFromBackupCR, *toRestore)
+	return h.createFromDependencyGraph(ownerToDependentsList, created, numOwnerReferences, objFromBackupCR, *toRestore, crdsWithSubStatus)
 }
 
 // generateDependencyGraph creates a graph "ownerToDependentsList" to track objects with ownerReferences
@@ -508,7 +522,7 @@ func customize(obj *unstructured.Unstructured) {
 }
 
 func (h *handler) createFromDependencyGraph(ownerToDependentsList map[string][]restoreObj, created map[string]bool,
-	numOwnerReferences map[string]int, objFromBackupCR ObjectsFromBackupCR, toRestore []restoreObj) error {
+	numOwnerReferences map[string]int, objFromBackupCR ObjectsFromBackupCR, toRestore []restoreObj, crdsWithSubStatus []string) error {
 	numTotalDependents := 0
 	for _, dependents := range ownerToDependentsList {
 		numTotalDependents += len(dependents)
@@ -538,7 +552,9 @@ func (h *handler) createFromDependencyGraph(ownerToDependentsList map[string][]r
 		} else {
 			resourceData = objFromBackupCR.clusterscopedResourceInfoToData[currResourceInfo]
 		}
-		if err := h.restoreResource(currResourceInfo, resourceData, objFromBackupCR.resourcesWithStatusSubresource[curr.GVR.String()]); err != nil {
+		target := fmt.Sprintf("%s.%s", currResourceInfo.GVR.Resource, currResourceInfo.GVR.GroupVersion().String())
+		hasSubStatus := slice.ContainsString(crdsWithSubStatus, target)
+		if err := h.restoreResource(currResourceInfo, resourceData, hasSubStatus); err != nil {
 			logrus.Errorf("Error restoring resource %v of type %v: %v", currResourceInfo.Name, currResourceInfo.GVR.String(), err)
 			errList = append(errList, fmt.Errorf("error restoring %v of type %v: %v", currResourceInfo.Name, currResourceInfo.GVR.String(), err))
 			continue

--- a/pkg/controllers/restore/download.go
+++ b/pkg/controllers/restore/download.go
@@ -74,11 +74,6 @@ func (h *handler) LoadFromTarGzip(tarGzFilePath string, transformerMap map[schem
 					return fmt.Errorf("error unmarshaling backup filters file: %v", err)
 				}
 			}
-			if strings.Contains(tarContent.Name, "statussubresource.json") {
-				if err := json.Unmarshal(readData, &cr.resourcesWithStatusSubresource); err != nil {
-					return fmt.Errorf("error unmarshaling status subresource info file: %v", err)
-				}
-			}
 			continue
 		}
 

--- a/pkg/controllers/restore/prune.go
+++ b/pkg/controllers/restore/prune.go
@@ -33,7 +33,7 @@ func (h *handler) prune(resourceSelectors []v1.ResourceSelector, transformerMap 
 		TransformerMap:  transformerMap,
 	}
 
-	if _, err := rh.GatherResources(h.ctx, resourceSelectors); err != nil {
+	if err := rh.GatherResources(h.ctx, resourceSelectors); err != nil {
 		return err
 	}
 
@@ -48,7 +48,7 @@ func (h *handler) prune(resourceSelectors []v1.ResourceSelector, transformerMap 
 				resourcePath = filepath.Join(resourcePath, objNs)
 			}
 			resourceFilePath := filepath.Join(resourcePath, objName+".json")
-			logrus.Infof("resourceFilePath: %v", resourceFilePath)
+			logrus.Debugf("resourceFilePath: %v", resourceFilePath)
 			if !cr.resourcesFromBackup[resourceFilePath] {
 				logrus.Infof("Marking resource %v for deletion", strings.TrimSuffix(resourceFilePath, ".json"))
 				resourcesToDelete = append(resourcesToDelete, pruneResourceInfo{


### PR DESCRIPTION
issue: https://github.com/rancher/rancher/issues/34193

drop the file `statussubresource.json` and implement a new approach to restore resources the subresource Status

Bug:
While going through the collected resources, the current implementation checks if its name is `xxx/status` and supports the update operation; if so, add its parent resource kind to a list that is saved to a file. And the list is used as the source of truth for determining if the status of a resource needs to be updated. 
And its problem is that if the rules in the resourceSet are strict, we will miss the status resource, therefore not update the status after restoring. 

Fix:
The new approach: when restoring the CRDs, if we see the `spec.subresources.status` filed, it means this kind of resource has the status subresource that needs to be restored. We save the names of those CRD into a list, then when restoring other resources, we will update its status if its kind is in the list. 
The new approach is more robust as it checks the CRD directly instead of depending on collected resources. 


TODO:

- [ ] backport to  the 2.5 line