### PR TITLE
[release/v1.0] add the annotation for setting the range of supported rancher version

### DIFF
--- a/charts/rancher-backup/Chart.yaml
+++ b/charts/rancher-backup/Chart.yaml
@@ -18,3 +18,4 @@ annotations:
   catalog.cattle.io/release-name: rancher-backup
   catalog.cattle.io/scope: management
   catalog.cattle.io/ui-component: rancher-backup
+  catalog.cattle.io/rancher-version: "<2.5.99"


### PR DESCRIPTION
The branch release/v1.0 is to cut rancher-backup 1.x for rancher v2.5.x line. 