### PR TITLE
[master] add the annotation for setting the range of supported rancher version

### DIFF
--- a/charts/rancher-backup/Chart.yaml
+++ b/charts/rancher-backup/Chart.yaml
@@ -19,3 +19,4 @@ annotations:
   catalog.cattle.io/release-name: rancher-backup
   catalog.cattle.io/scope: management
   catalog.cattle.io/ui-component: rancher-backup
+  catalog.cattle.io/rancher-version: ">=2.6.0"


### PR DESCRIPTION
The branch master is to cut rancher-backup 2.x for rancher v2.6.x line.