### PR TITLE
fix the annotation to allow the chart to show on rancher RC release

### DIFF
--- a/charts/rancher-backup-crd/Chart.yaml
+++ b/charts/rancher-backup-crd/Chart.yaml
@@ -9,3 +9,4 @@ annotations:
   catalog.cattle.io/hidden: "true"
   catalog.cattle.io/namespace: cattle-resources-system
   catalog.cattle.io/release-name: rancher-backup-crd
+  catalog.cattle.io/rancher-version: "<2.5.99-0"

--- a/charts/rancher-backup/Chart.yaml
+++ b/charts/rancher-backup/Chart.yaml
@@ -18,4 +18,4 @@ annotations:
   catalog.cattle.io/release-name: rancher-backup
   catalog.cattle.io/scope: management
   catalog.cattle.io/ui-component: rancher-backup
-  catalog.cattle.io/rancher-version: "<2.5.99"
+  catalog.cattle.io/rancher-version: "<2.5.99-0"


### PR DESCRIPTION
"<2.5.99-0" makes the chart show on rancher `2.5.10-rc1` 