### PR TITLE
Fix backup for fleet

### DIFF
--- a/pkg/controllers/restore/controller.go
+++ b/pkg/controllers/restore/controller.go
@@ -42,6 +42,7 @@ const (
 	clusterScoped      = "clusterscoped"
 	namespaceScoped    = "namespaceScoped"
 	leaseName          = "restore-controller"
+	secretsMapKey      = "secrets"
 	specMapKey         = "spec"
 	subResourcesMapKey = "subresources"
 	versionMapKey      = "versions"
@@ -393,6 +394,8 @@ func (h *handler) generateDependencyGraph(ownerToDependentsList map[string][]res
 			Data:               &resourceData,
 		}
 
+		customize(&resourceData)
+
 		metadata := resourceData.Object[metadataMapKey].(map[string]interface{})
 		ownerRefs, ownerRefsFound := metadata[ownerRefsMapKey].([]interface{})
 		if !ownerRefsFound {
@@ -494,6 +497,29 @@ func (h *handler) generateDependencyGraph(ownerToDependentsList map[string][]res
 		}
 	}
 	return nil
+}
+
+// customize provides customization of restored resource for edge cases
+func customize(obj *unstructured.Unstructured) {
+	switch obj.GetKind() {
+	case "ServiceAccount":
+		// remove secrets section as referenced secrets will be removed by k8s Token Controller as they are considered orphaned
+		delete(obj.Object, secretsMapKey)
+		logrus.Debugf("Secrets section is ignored in ServiceAccount %s/%s", obj.GetNamespace(), obj.GetName())
+	case "Cluster":
+		// for fleet cluster it needs to be reimported in order to reissue service account token that is no longer valid
+		if obj.GetAPIVersion() == "fleet.cattle.io/v1alpha1" {
+			// only warn error if field can't be found. In case there are breaking api changes error will be printed as Warn and user has workaround to patch it.
+			redeployAgentGeneration, _, err := unstructured.NestedInt64(obj.Object, "spec", "redeployAgentGeneration")
+			if err != nil {
+				logrus.Warnf("Fleet cluster %s/%s can't be reset to be re-imported, failed to fetch .spec.redeployAgentGeneration, error: %v", obj.GetNamespace(), obj.GetName(), err)
+				return
+			}
+			if err := unstructured.SetNestedField(obj.Object, redeployAgentGeneration+1, "spec", "redeployAgentGeneration"); err != nil {
+				logrus.Warnf("Fleet cluster %s/%s can't be reset to be re-imported, error: %v", obj.GetNamespace(), obj.GetName(), err)
+			}
+		}
+	}
 }
 
 func (h *handler) createFromDependencyGraph(ownerToDependentsList map[string][]restoreObj, created map[string]bool,


### PR DESCRIPTION
https://github.com/rancher/backup-restore-operator/issues/164

Note: During the backup and restore, user will most likely hit this fleet issue. https://github.com/rancher/fleet/issues/535 This fleet issue should be fixed by latest version of fleet(v0.3.7), which we also need to update latest fleet to 2.5 branch. 