### PR TITLE
Spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ### Description
 
-* This operator provides ability to backup and restore Kubernetes applications (metadata) running on any cluster. It accepts a list of resources that need to be backed up for a particular application. It then gathers these resources by querying the Kubernetes API server, packages all the resources to create a tarball file and pushes it to the configured backup storage location. Since it gathers resources by quering the API server, it can back up applications from any type of Kubernetes cluster.
+* This operator provides ability to backup and restore Kubernetes applications (metadata) running on any cluster. It accepts a list of resources that need to be backed up for a particular application. It then gathers these resources by querying the Kubernetes API server, packages all the resources to create a tarball file and pushes it to the configured backup storage location. Since it gathers resources by querying the API server, it can back up applications from any type of Kubernetes cluster.
 * The operator preserves the ownerReferences on all resources, hence maintaining dependencies between objects.
 * It also provides encryption support, to encrypt user specified resources before saving them in the backup file. It uses the same encryption configuration that is used to enable [Kubernetes Encryption at Rest](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/). Follow the steps in [this section](https://rancher.com/docs/rancher/v2.5/en/backups/configuration/backup-config/#encryption) to configure this.
 

--- a/main.go
+++ b/main.go
@@ -102,7 +102,7 @@ func main() {
 		logrus.Fatalf("Error getting kubernetes client: %s", err.Error())
 	}
 
-	dynamicInterace, err := dynamic.NewForConfig(restKubeConfig)
+	dynamicInterface, err := dynamic.NewForConfig(restKubeConfig)
 	if err != nil {
 		logrus.Fatalf("Error generating dynamic client: %s", err.Error())
 	}
@@ -172,12 +172,12 @@ func main() {
 		backups.Resources().V1().ResourceSet(),
 		core.Core().V1().Secret(),
 		core.Core().V1().Namespace(),
-		clientSet, dynamicInterace, defaultMountPath, defaultS3)
+		clientSet, dynamicInterface, defaultMountPath, defaultS3)
 	restore.Register(ctx, backups.Resources().V1().Restore(),
 		backups.Resources().V1().Backup(),
 		core.Core().V1().Secret(),
 		k8sclient.CoordinationV1().Leases(ChartNamespace),
-		clientSet, dynamicInterace, sharedClientFactory, restmapper, defaultMountPath, defaultS3)
+		clientSet, dynamicInterface, sharedClientFactory, restmapper, defaultMountPath, defaultS3)
 
 	if err := start.All(ctx, 2, backups); err != nil {
 		logrus.Fatalf("Error starting: %s", err.Error())

--- a/pkg/controllers/restore/download.go
+++ b/pkg/controllers/restore/download.go
@@ -123,8 +123,8 @@ func (h *handler) loadDataFromFile(tarContent *tar.Header, readData []byte,
 	if err != nil {
 		if strings.Contains(err.Error(), "json: cannot unmarshal string into Go value") && decryptionTransformer == nil {
 			// This will be the case if we try to unmarshal an encrypted resource without decrypting it first
-			logrus.Errorf("Error unmarshaling encryped resource [%v], no encryption config provided ", gvr.GroupResource())
-			return fmt.Errorf("error unmarshaling encryped resource [%v], no encryption config provided", gvr.GroupResource())
+			logrus.Errorf("Error unmarshaling encrypted resource [%v], no encryption config provided ", gvr.GroupResource())
+			return fmt.Errorf("error unmarshaling encrypted resource [%v], no encryption config provided", gvr.GroupResource())
 		}
 		return err
 	}

--- a/pkg/controllers/restore/pause.go
+++ b/pkg/controllers/restore/pause.go
@@ -63,7 +63,7 @@ func (h *handler) getObjFromControllerRef(controllerRef v1.ControllerReference) 
 	var dr dynamic.ResourceInterface
 	gv, err := schema.ParseGroupVersion(controllerRef.APIVersion)
 	if err != nil {
-		logrus.Errorf("Error parsing apiverion %v for controllerRef %v, skipping it", controllerRef.APIVersion, controllerRef.Name)
+		logrus.Errorf("Error parsing apiversion %v for controllerRef %v, skipping it", controllerRef.APIVersion, controllerRef.Name)
 		return nil, dr
 	}
 	gvr := gv.WithResource(controllerRef.Resource)


### PR DESCRIPTION
This PR corrects misspellings identified by the [check-spelling action](https://github.com/marketplace/actions/check-spelling).

The misspellings have been reported at https://github.com/jsoref/rancher-backup-restore-operator/commit/b7c0564d91f72b361974c164af6ad6993e867075#commitcomment-66609526

The action reports that the changes in this PR would make it happy: https://github.com/jsoref/rancher-backup-restore-operator/commit/d4936373da05e638bc3389137c8d81626ad75319

Note: this PR does not include the action. If you're interested in running a spell check on every PR and push, that can be offered separately.