### PR TITLE
Provide better errors around s3

### DIFF
--- a/main.go
+++ b/main.go
@@ -41,6 +41,8 @@ var (
 	OperatorPVEnabled               string
 	OperatorS3BackupStorageLocation string
 	ChartNamespace                  string
+	Debug                           bool
+	Trace                           bool
 )
 
 type objectStore struct {
@@ -56,6 +58,9 @@ type objectStore struct {
 
 func init() {
 	flag.StringVar(&KubeConfig, "kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
+	flag.BoolVar(&Debug, "debug", false, "Enable debug logging.")
+	flag.BoolVar(&Trace, "trace", false, "Enable trace logging.")
+
 	flag.Parse()
 	OperatorPVEnabled = os.Getenv("DEFAULT_PERSISTENCE_ENABLED")
 	OperatorS3BackupStorageLocation = os.Getenv("DEFAULT_S3_BACKUP_STORAGE_LOCATION")
@@ -66,6 +71,14 @@ func main() {
 	var defaultS3 *v1.S3ObjectStore
 	var objStoreWithStrSkipVerify *objectStore
 	var defaultMountPath string
+	if Debug {
+		logrus.SetLevel(logrus.DebugLevel)
+		logrus.Debugf("Loglevel set to [%v]", logrus.DebugLevel)
+	}
+	if Trace {
+		logrus.SetLevel(logrus.TraceLevel)
+		logrus.Tracef("Loglevel set to [%v]", logrus.TraceLevel)
+	}
 
 	logrus.Infof("Starting backup-restore controller version %s (%s)", Version, GitCommit)
 	logrus.SetFormatter(&logrus.TextFormatter{FullTimestamp: true, ForceColors: true, TimestampFormat: LogFormat})

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,3 +1,3 @@
 FROM registry.suse.com/suse/sle15:15.3
 COPY bin/backup-restore-operator /usr/bin/
-CMD ["backup-restore-operator"]
+ENTRYPOINT ["backup-restore-operator"]


### PR DESCRIPTION
https://github.com/rancher/backup-restore-operator/issues/203

Although we can't really check base64 encoded values (as there is no strict check for it), we can add logging the values under debug and trace (sensitive) to help troubleshoot. Also the context of a lot of errors/logging as not there, so I added it.

This also changes `CMD` to `ENTRYPOINT` so we can use `args` to the Deployment (`-debug` and `-trace`)