### PR TITLE
Add support for specifying a proxy

### DIFF
--- a/charts/rancher-backup/templates/deployment.yaml
+++ b/charts/rancher-backup/templates/deployment.yaml
@@ -38,6 +38,14 @@ spec:
           {{- if .Values.persistence.enabled }}
         - name: DEFAULT_PERSISTENCE_ENABLED
           value: "persistence-enabled"
+{{- if .Values.proxy }}
+        - name: HTTP_PROXY
+          value: {{ .Values.proxy }}
+        - name: HTTPS_PROXY
+          value: {{ .Values.proxy }}
+        - name: NO_PROXY
+          value: {{ .Values.noProxy }}
+{{- end }}
         volumeMounts:
         - mountPath: "/var/lib/backups"
           name: pv-storage

--- a/charts/rancher-backup/values.yaml
+++ b/charts/rancher-backup/values.yaml
@@ -37,6 +37,11 @@ persistence:
   ## Only certain StorageClasses allow resizing PVs; Refer https://kubernetes.io/blog/2018/07/12/resizing-persistent-volumes-using-kubernetes/
   size: 2Gi
 
+# http[s] proxy server passed to backup client
+# proxy: http://<username>@<password>:<url>:<port>
+
+# comma separated list of domains or ip addresses that will not use the proxy
+noProxy: 127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.svc,.cluster.local
 
 global:
   cattle:


### PR DESCRIPTION
Amend the Deployment template so that users can pass a HTTP(s) proxy
that the backup operator will use when uploading to the configured
target.

Fixes #106 