### PR TITLE
Do not backup bootstrap-secret

### DIFF
--- a/charts/rancher-backup/files/default-resourceset-contents/rancher.yaml
+++ b/charts/rancher-backup/files/default-resourceset-contents/rancher.yaml
@@ -11,6 +11,7 @@
       - key: "owner"
         operator: "NotIn"
         values: ["helm"]
+  excludeResourceNameRegexp: "^bootstrap-secret$"
 - apiVersion: "v1"
   kindsRegexp: "^serviceaccounts$"
   namespaceRegexp: "^cattle-|^p-|^c-|^local$|^user-|^u-"


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/37060

Although the PR in `rancher/rancher` (https://github.com/rancher/rancher/pull/37369) solves most (if not all) situations where this was an issue, the bootstrap secret has no use to be backed up, as Rancher will be reinstalled and during install it can be decided to set a bootstrap password or let one be generated (like a normal install)