### PR TITLE
Make imagePullPolicy configurable in chart

### DIFF
--- a/charts/rancher-backup/templates/deployment.yaml
+++ b/charts/rancher-backup/templates/deployment.yaml
@@ -27,7 +27,7 @@ spec:
       containers:
       - name: {{ .Chart.Name }}
         image: {{ template "system_default_registry" . }}{{ .Values.image.repository }}:{{ .Values.image.tag }}
-        imagePullPolicy: Always
+        imagePullPolicy: {{ default "Always" .Values.imagePullPolicy }}
         env:
         - name: CHART_NAMESPACE
           value: {{ .Release.Namespace }}

--- a/charts/rancher-backup/values.yaml
+++ b/charts/rancher-backup/values.yaml
@@ -64,3 +64,8 @@ serviceAccount:
   annotations: {}
 
 priorityClassName: ""
+
+# Override imagePullPolicy for image
+# options: Always, Never, IfNotPresent
+# Defaults to Always
+# imagePullPolicy: <pullPolicy>


### PR DESCRIPTION
https://github.com/rancher/backup-restore-operator/issues/212

Similarly implemented as in `rancher/rancher`: https://github.com/rancher/rancher/blob/release/v2.6/chart/templates/deployment.yaml#L67