### PR TITLE
Setting Version the correct way

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -9,8 +9,8 @@ mkdir -p bin
 if [ "$(uname)" = "Linux" ]; then
     OTHER_LINKFLAGS="-extldflags -static -s"
 fi
-LINKFLAGS="-X github.com/rancher/backup-restore-operator.Version=$VERSION"
-LINKFLAGS="-X github.com/rancher/backup-restore-operator.GitCommit=$COMMIT $LINKFLAGS"
+LINKFLAGS="-X main.Version=$VERSION"
+LINKFLAGS="-X main.GitCommit=$COMMIT $LINKFLAGS"
 CGO_ENABLED=0 go build -ldflags "$LINKFLAGS $OTHER_LINKFLAGS" -o bin/backup-restore-operator
 if [ "$CROSS" = "true" ] && [ "$ARCH" = "amd64" ]; then
     GOOS=darwin go build -ldflags "$LINKFLAGS" -o bin/backup-restore-operator-darwin


### PR DESCRIPTION
Current RCs have the following log and are not setting Version or Commit correctly:

```
INFO[2022/05/05 06:16:07] Starting backup-restore controller version v0.0.0-dev (HEAD) 
```