### PR TITLE
More minio helper commmands

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -18,20 +18,7 @@ helm install --wait \
 ### Developer Help Script
 For help with setting up the environment, check out `/scripts/deploy`. It has some helpful functions for deploying the various components used in the development environment.
 
-The function options include:
-./deploy [template/publish/minio/backup-restore/backup/remove-charts/clean/help]
-
-The following variables can be exported to access more functionality:
-
-    KUBECONFIG          Path to your cluster's kube config file.
-
-    DOCKERHUB_USER      Your docker hub username to be used for the image repo.
-                        With this exported you can publish the local image to  
-                        allow it to be to be deployed on a remote host."
-
-    USE_DOCKER_BUILDX   This flag will force the package script to use docker 
-                        buildx, setting the target platform to build for amd64 
-                        This is useful when developing on different architectures.
+To see all available options, run `./scripts/deploy help`.
 
 #### Example Usage
 
@@ -66,6 +53,11 @@ make package
 ```
 
 Note: if `DOCKERHUB_USER` is exported then the script will set the image repo to pull from your dockerhub, if not it will use the Public Rancher image instead.
+
+If you want to interact with the Minio deployed in the cluster, you can use the following arguments:
+
+* `list-minio-files`: List all the files currently stored in the bucket `rancherbackups` in Minio
+* `copy-minio-files`: Copy all the files currently stored in the bucket `rancherbackups` in Minio to the local directory `minio-files-$EPOCH`
 
 ### Building on Different Architectures
 

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -21,8 +21,6 @@ RUN if [ "${ARCH}" != "s390x" ]; then \
 RUN if [ "${ARCH}" == "amd64" ]; then \
         curl -sL https://github.com/rancher/k3s/releases/download/$(curl -Ls -o /dev/null -w %{url_effective} https://update.k3s.io/v1-release/channels/stable | awk -F/ '{ print $NF }')/k3s > /usr/local/bin/k3s \
         && chmod +x /usr/local/bin/k3s \
-        && curl -sL https://github.com/minio/certgen/releases/latest/download/certgen-linux-amd64 > /usr/local/bin/certgen \
-        && chmod +x /usr/local/bin/certgen \
         && curl -sL https://dl.min.io/client/mc/release/linux-amd64/mc > /usr/local/bin/mc \
         && chmod +x /usr/local/bin/mc; \
     fi

--- a/scripts/deploy
+++ b/scripts/deploy
@@ -12,8 +12,9 @@ check_kubeconfig() {
   fi
 }
 
-create_cert() {
-  cat <<EOF > public.crt
+deploy_minio() {
+  local PUBLIC_CRT
+  PUBLIC_CRT=$(cat <<EOF
 -----BEGIN CERTIFICATE-----
 MIICSTCCAe+gAwIBAgIQWgUVWCiZdyOGruNe6m4iWjAKBggqhkjOPQQDAjBMMRww
 GgYDVQQKExNDZXJ0Z2VuIERldmVsb3BtZW50MSwwKgYDVQQLDCNlbGl5YW1sZXZ5
@@ -30,17 +31,17 @@ LNeXJmh2lnqEvaeKgqLHPFgMOQg+4TyO+uQCIQCI5WX1E84B+z6yX7WKIBYJIjto
 RjQi75QniF10pi2jKA==
 -----END CERTIFICATE-----
 EOF
-
-  cat <<EOF > private.key
+  )
+  local PRIVATE_KEY
+  PRIVATE_KEY=$(cat <<EOF
 -----BEGIN PRIVATE KEY-----
 MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgRiROiBUTvzxfDbiu
 60w9WdlRKAI7Jy0c26uC2FoAZdahRANCAAQUfxQ8KX+8AeQxtMXcTzKFJ0s0fZe5
 4pQeez47gVGGfT3o4kqcZkVv8eJb2IlaGPgIngu5tK+yJklnti4OUz19
 -----END PRIVATE KEY-----
 EOF
-}
+  )
 
-deploy_minio() {
   KUBECTL_CMD="kubectl"
   if command -v k3s &> /dev/null ; then
       KUBECTL_CMD="k3s kubectl"
@@ -55,7 +56,7 @@ deploy_minio() {
   ${KUBECTL_CMD} create ns minio
 
   echo "Creating Minio tls-ssl secret"
-  ${KUBECTL_CMD} -n minio create secret generic tls-ssl-minio --from-file=private.key --from-file=public.crt
+  ${KUBECTL_CMD} -n minio create secret generic tls-ssl-minio --from-literal=private.key="$PRIVATE_KEY" --from-literal=public.crt="$PUBLIC_CRT"
 
   echo "Installing Minio"
   helm install --namespace minio --set rootUser=inspectorgadget,rootPassword=gogadgetgo --set tls.enabled=true,tls.certSecret=tls-ssl-minio --set replicas=1 --set resources.requests.memory=2Gi --set persistence.enabled=false --set drivesPerNode=0 --set pools=0 --set mode=standalone --set buckets[0].name=rancherbackups --set buckets[0].policy=none --set buckets[0].purge=true minio minio/minio
@@ -63,6 +64,55 @@ deploy_minio() {
   while ! (${KUBECTL_CMD} --namespace minio rollout status --timeout 15s deploy/minio 2>/dev/null); do sleep 5; done
 
   ${KUBECTL_CMD} create secret generic miniocreds --from-literal=accessKey=inspectorgadget --from-literal=secretKey=gogadgetgo
+}
+
+list_minio_files() {
+  KUBECTL_CMD="kubectl"
+  if command -v k3s &> /dev/null ; then
+      KUBECTL_CMD="k3s kubectl"
+  else
+    check_kubeconfig
+  fi
+
+  local POD_NAME
+  POD_NAME=$("${KUBECTL_CMD}" get pods --namespace minio -l "release=minio" -o jsonpath="{.items[0].metadata.name}")
+  ${KUBECTL_CMD} port-forward $POD_NAME 9000 --namespace minio &
+  sleep 5
+
+  DOCKER_HOSTNAME="127.0.0.1"
+  if [[ "$(docker info -f'{{.Name}}')" == "lima-rancher-desktop" ]] || [[ "$(docker info -f'{{.Name}}')" == "docker-desktop" ]]; then
+      DOCKER_HOSTNAME="host.docker.internal"
+  fi
+
+  docker run --rm --net=host -e MC_HOST_miniolocal=https://inspectorgadget:gogadgetgo@${DOCKER_HOSTNAME}:9000 minio/mc ls --insecure miniolocal/rancherbackups
+  kill -9 "$(pgrep -f "kubectl port-forward minio")"
+}
+
+copy_minio_files() {
+  KUBECTL_CMD="kubectl"
+  if command -v k3s &> /dev/null ; then
+      KUBECTL_CMD="k3s kubectl"
+  else
+    check_kubeconfig
+  fi
+
+  local POD_NAME
+  POD_NAME=$("${KUBECTL_CMD}" get pods --namespace minio -l "release=minio" -o jsonpath="{.items[0].metadata.name}")
+  ${KUBECTL_CMD} port-forward $POD_NAME 9000 --namespace minio &
+  sleep 5
+
+  DOCKER_HOSTNAME="127.0.0.1"
+  if [[ "$(docker info -f'{{.Name}}')" == "lima-rancher-desktop" ]] || [[ "$(docker info -f'{{.Name}}')" == "docker-desktop" ]]; then
+      DOCKER_HOSTNAME="host.docker.internal"
+  fi
+
+  MINIO_FILES_DIR="minio-files-$(date +%s)"
+  mkdir $MINIO_FILES_DIR
+
+  docker run --rm --net=host -v "${PWD}/${MINIO_FILES_DIR}":/data -e MC_HOST_miniolocal=https://inspectorgadget:gogadgetgo@${DOCKER_HOSTNAME}:9000 minio/mc cp --insecure --recursive miniolocal/rancherbackups/ /data/
+  kill -9 "$(pgrep -f "kubectl port-forward minio")"
+
+  echo "Copied all files from Minio to ./${MINIO_FILES_DIR}"
 }
 
 deploy_backup_restore() {
@@ -89,11 +139,6 @@ deploy_backup_restore() {
 
 create_backup() {
   KUBECTL_CMD="kubectl"
-  if [[ $(uname -s) = "Darwin" ]]; then
-    BASE64CA=$(cat public.crt |base64)
-  elif [[ $(uname -s) = "Linux" ]]; then
-    BASE64CA=$(cat public.crt |base64 -w0)
-  fi
 
   if command -v k3s &> /dev/null ; then
     KUBECTL_CMD="k3s kubectl"
@@ -101,7 +146,7 @@ create_backup() {
     check_kubeconfig
   fi
 
-  cat <<EOF > backup.yaml
+${KUBECTL_CMD} create -f - <<EOF
 apiVersion: resources.cattle.io/v1
 kind: Backup
 metadata:
@@ -113,13 +158,11 @@ spec:
       credentialSecretNamespace: default
       bucketName: rancherbackups
       endpoint: minio.minio.svc.cluster.local:9000
-      endpointCA: ${BASE64CA}
+      endpointCA: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUNTVENDQWUrZ0F3SUJBZ0lRV2dVVldDaVpkeU9HcnVOZTZtNGlXakFLQmdncWhrak9QUVFEQWpCTU1Sd3cKR2dZRFZRUUtFeE5EWlhKMFoyVnVJRVJsZG1Wc2IzQnRaVzUwTVN3d0tnWURWUVFMRENObGJHbDVZVzFzWlhaNQpRRVZzYVhsaGJYTXRUVUpRTG1GMGRHeHZZMkZzTG01bGREQWVGdzB5TWpBMU1URXhOREF4TWpCYUZ3MHpNakExCk1URXdNakF4TWpCYU1Fd3hIREFhQmdOVkJBb1RFME5sY25SblpXNGdSR1YyWld4dmNHMWxiblF4TERBcUJnTlYKQkFzTUkyVnNhWGxoYld4bGRubEFSV3hwZVdGdGN5MU5RbEF1WVhSMGJHOWpZV3d1Ym1WME1Ga3dFd1lIS29aSQp6ajBDQVFZSUtvWkl6ajBEQVFjRFFnQUVGSDhVUENsL3ZBSGtNYlRGM0U4eWhTZExOSDJYdWVLVUhucytPNEZSCmhuMDk2T0pLbkdaRmIvSGlXOWlKV2hqNENKNEx1YlN2c2laSlo3WXVEbE05ZmFPQnNqQ0JyekFPQmdOVkhROEIKQWY4RUJBTUNBcVF3RXdZRFZSMGxCQXd3Q2dZSUt3WUJCUVVIQXdFd0R3WURWUjBUQVFIL0JBVXdBd0VCL3pBZApCZ05WSFE0RUZnUVVJbWpyZXNxbDc4ZkJwd1NWN2xwNGZUNCtObnd3V0FZRFZSMFJCRkV3VDRJRmJXbHVhVytDCkMyMXBibWx2TG0xcGJtbHZnZzl0YVc1cGJ5NXRhVzVwYnk1emRtT0NIVzFwYm1sdkxtMXBibWx2TG5OMll5NWoKYkhWemRHVnlMbXh2WTJGc2dnbHNiMk5oYkdodmMzUXdDZ1lJS29aSXpqMEVBd0lEU0FBd1JRSWdXVDRDVTVpYgpMTmVYSm1oMmxucUV2YWVLZ3FMSFBGZ01PUWcrNFR5Tyt1UUNJUUNJNVdYMUU4NEIrejZ5WDdXS0lCWUpJanRvClJqUWk3NVFuaUYxMHBpMmpLQT09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
   resourceSetName: rancher-resource-set
   schedule: "@every 30s"
   retentionCount: 2
 EOF
-
-  ${KUBECTL_CMD} create -f backup.yaml
 }
 
 uninstall_charts() {
@@ -150,7 +193,7 @@ retag_and_push() {
 }
 
 script-info() {
-  echo "./deploy [template/publish/minio/backup-restore/create-backup/remove-charts/clean]"
+  echo "./deploy [template/publish/minio/list-minio-files/copy-minio-files/backup-restore/create-backup/remove-charts]"
   if [ -z "${KUBECONFIG}" ] || [ -z "${DOCKERHUB_USER}" ] || [ -z "${USE_DOCKER_BUILDX}" ] ; then
     echo ""
     echo "The following variables can be exported to access more functionality (See Descriptions)."
@@ -186,14 +229,18 @@ case $1 in
     ;;
 
     minio)
-      create_cert
       deploy_minio
     ;;
 
+    list-minio-files)
+      list_minio_files
+    ;;
+
+    copy-minio-files)
+      copy_minio_files
+    ;;
+
     backup-restore)
-      if [ ! -f "public.crt" ] || [ ! -f "private.key" ]; then
-          create_cert
-      fi
       deploy_backup_restore
     ;;
 
@@ -203,10 +250,6 @@ case $1 in
 
     remove-charts)
       uninstall_charts
-    ;;
-
-    clean)
-      rm private.key public.crt backup.yaml
     ;;
 
     help)

--- a/scripts/integration
+++ b/scripts/integration
@@ -61,7 +61,26 @@ k3s kubectl port-forward $POD_NAME 9000 --namespace minio &
 sleep 10
 
 mkdir -p $HOME/.mc/certs/CAs
-cp public.crt $HOME/.mc/certs/CAs
+PUBLIC_CRT=$(cat <<EOF
+-----BEGIN CERTIFICATE-----
+MIICSTCCAe+gAwIBAgIQWgUVWCiZdyOGruNe6m4iWjAKBggqhkjOPQQDAjBMMRww
+GgYDVQQKExNDZXJ0Z2VuIERldmVsb3BtZW50MSwwKgYDVQQLDCNlbGl5YW1sZXZ5
+QEVsaXlhbXMtTUJQLmF0dGxvY2FsLm5ldDAeFw0yMjA1MTExNDAxMjBaFw0zMjA1
+MTEwMjAxMjBaMEwxHDAaBgNVBAoTE0NlcnRnZW4gRGV2ZWxvcG1lbnQxLDAqBgNV
+BAsMI2VsaXlhbWxldnlARWxpeWFtcy1NQlAuYXR0bG9jYWwubmV0MFkwEwYHKoZI
+zj0CAQYIKoZIzj0DAQcDQgAEFH8UPCl/vAHkMbTF3E8yhSdLNH2XueKUHns+O4FR
+hn096OJKnGZFb/HiW9iJWhj4CJ4LubSvsiZJZ7YuDlM9faOBsjCBrzAOBgNVHQ8B
+Af8EBAMCAqQwEwYDVR0lBAwwCgYIKwYBBQUHAwEwDwYDVR0TAQH/BAUwAwEB/zAd
+BgNVHQ4EFgQUImjresql78fBpwSV7lp4fT4+NnwwWAYDVR0RBFEwT4IFbWluaW+C
+C21pbmlvLm1pbmlvgg9taW5pby5taW5pby5zdmOCHW1pbmlvLm1pbmlvLnN2Yy5j
+bHVzdGVyLmxvY2Fsgglsb2NhbGhvc3QwCgYIKoZIzj0EAwIDSAAwRQIgWT4CU5ib
+LNeXJmh2lnqEvaeKgqLHPFgMOQg+4TyO+uQCIQCI5WX1E84B+z6yX7WKIBYJIjto
+RjQi75QniF10pi2jKA==
+-----END CERTIFICATE-----
+EOF
+)
+
+echo "$PUBLIC_CRT" > $HOME/.mc/certs/CAs/public.crt
 export MC_HOST_miniolocal=https://inspectorgadget:gogadgetgo@localhost:9000
 mc ls --quiet --no-color miniolocal/rancherbackups
 FIRSTBACKUP=$(mc ls --quiet --no-color miniolocal/rancherbackups | awk '{ print $NF }')


### PR DESCRIPTION
* Removes creation of local files for certificates and `backup.yaml`
* Adds `list-minio-files` option to deploy script, to list all files in the rancherbackups bucket in Minio
* Adds `copy-minio-files` option to deploy script, to copy all files in the rancherbackups bucket in Minio to local
* Remove `certgen` from `Dockerfile.dapper` as we use static certificates now