### PR TITLE
Add minio helpers for file and bucket interactions

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -18,7 +18,7 @@ helm install --wait \
 ### Developer Help Script
 For help with setting up the environment, check out `/scripts/deploy`. It has some helpful functions for deploying the various components used in the development environment.
 
-To see all available options, run `./scripts/deploy help`.
+To see all available options, run `./scripts/deploy`.
 
 #### Example Usage
 
@@ -57,7 +57,9 @@ Note: if `DOCKERHUB_USER` is exported then the script will set the image repo to
 If you want to interact with the Minio deployed in the cluster, you can use the following arguments:
 
 * `list-minio-files`: List all the files currently stored in the bucket `rancherbackups` in Minio
-* `copy-minio-files`: Copy all the files currently stored in the bucket `rancherbackups` in Minio to the local directory `minio-files-$EPOCH`
+* `retrieve-minio-files`: Copy all the files currently stored in the bucket `rancherbackups` in Minio to the local directory `minio-files-$EPOCH`
+* `copy-minio-files`: Copy all the files currently stored in a local directory (passed as first argument) to the bucket `rancherbackups` in Minio
+* `reset-minio-bucket`: Delete and create the `rancherbackups` bucket
 
 ### Building on Different Architectures
 

--- a/scripts/deploy
+++ b/scripts/deploy
@@ -1,15 +1,13 @@
 #!/bin/bash
 
 check_kubeconfig() {
-  if [ -z "${KUBECONFIG}" ]; then
-  echo "Please set your Kubeconfig environment variable before running."
-  exit 0
-  fi
-
   if ! kubectl get nodes >/dev/null 2>&1; then
-    echo "Please make sure your exported Kubeconfig is correct and pointing to the right cluster."
-    exit 1
+      echo "The command 'kubectl get nodes' returned an error"
+      echo "Either make sure ~/.kube/config is correctly configured or set the KUBECONFIG environment variable to the correct configuration file"
+      exit 1
   fi
+  echo "Communicating with cluster:"
+  kubectl get nodes -o wide
 }
 
 deploy_minio() {
@@ -88,7 +86,7 @@ list_minio_files() {
   kill -9 "$(pgrep -f "kubectl port-forward minio")"
 }
 
-copy_minio_files() {
+retrieve_minio_files() {
   KUBECTL_CMD="kubectl"
   if command -v k3s &> /dev/null ; then
       KUBECTL_CMD="k3s kubectl"
@@ -113,6 +111,58 @@ copy_minio_files() {
   kill -9 "$(pgrep -f "kubectl port-forward minio")"
 
   echo "Copied all files from Minio to ./${MINIO_FILES_DIR}"
+}
+
+copy_minio_files() {
+  KUBECTL_CMD="kubectl"
+  if command -v k3s &> /dev/null ; then
+      KUBECTL_CMD="k3s kubectl"
+  else
+    check_kubeconfig
+  fi
+
+  local POD_NAME
+  POD_NAME=$("${KUBECTL_CMD}" get pods --namespace minio -l "release=minio" -o jsonpath="{.items[0].metadata.name}")
+  ${KUBECTL_CMD} port-forward $POD_NAME 9000 --namespace minio &
+  sleep 5
+
+  DOCKER_HOSTNAME="127.0.0.1"
+  if [[ "$(docker info -f'{{.Name}}')" == "lima-rancher-desktop" ]] || [[ "$(docker info -f'{{.Name}}')" == "docker-desktop" ]]; then
+      DOCKER_HOSTNAME="host.docker.internal"
+  fi
+
+  SOURCE_FILES_DIR=$1
+  echo "Copying from directory ${SOURCE_FILES_DIR}"
+
+  docker run --rm --net=host -v "${PWD}/${SOURCE_FILES_DIR}":/data -e MC_HOST_miniolocal=https://inspectorgadget:gogadgetgo@${DOCKER_HOSTNAME}:9000 minio/mc cp --insecure --recursive /data/ miniolocal/rancherbackups/
+  kill -9 "$(pgrep -f "kubectl port-forward minio")"
+
+  echo "Copied all files from directory ${SOURCE_FILES_DIR} to Minio"
+}
+
+reset_minio_bucket() {
+  KUBECTL_CMD="kubectl"
+  if command -v k3s &> /dev/null ; then
+      KUBECTL_CMD="k3s kubectl"
+  else
+    check_kubeconfig
+  fi
+
+  local POD_NAME
+  POD_NAME=$("${KUBECTL_CMD}" get pods --namespace minio -l "release=minio" -o jsonpath="{.items[0].metadata.name}")
+  ${KUBECTL_CMD} port-forward $POD_NAME 9000 --namespace minio &
+  sleep 5
+
+  DOCKER_HOSTNAME="127.0.0.1"
+  if [[ "$(docker info -f'{{.Name}}')" == "lima-rancher-desktop" ]] || [[ "$(docker info -f'{{.Name}}')" == "docker-desktop" ]]; then
+      DOCKER_HOSTNAME="host.docker.internal"
+  fi
+
+  docker run --rm --net=host -e MC_HOST_miniolocal=https://inspectorgadget:gogadgetgo@${DOCKER_HOSTNAME}:9000 minio/mc rb --insecure --force miniolocal/rancherbackups
+  docker run --rm --net=host -e MC_HOST_miniolocal=https://inspectorgadget:gogadgetgo@${DOCKER_HOSTNAME}:9000 minio/mc mb --insecure miniolocal/rancherbackups
+  kill -9 "$(pgrep -f "kubectl port-forward minio")"
+
+  echo "Deleted and created the 'rancherbackups' bucket"
 }
 
 deploy_backup_restore() {
@@ -166,15 +216,7 @@ EOF
 }
 
 uninstall_charts() {
-  if [ -z "${KUBECONFIG}" ]; then
-   echo "Please set your Kubeconfig environment variable before running."
-   exit 0
-  fi
-  
-  if ! kubectl get nodes >/dev/null 2>&1; then
-    echo "Please make sure your exported Kubeconfig is correct and pointing to the right cluster."
-    exit 1
-  fi
+  check_kubeconfig
 
   helm uninstall -n minio minio
   helm uninstall -n cattle-resources-system rancher-backup
@@ -193,7 +235,7 @@ retag_and_push() {
 }
 
 script-info() {
-  echo "./deploy [template/publish/minio/list-minio-files/copy-minio-files/backup-restore/create-backup/remove-charts]"
+  echo "./deploy [template/publish/minio/list-minio-files/retrieve-minio-files/copy-minio-files/reset-minio-bucket/backup-restore/create-backup/remove-charts]"
   if [ -z "${KUBECONFIG}" ] || [ -z "${DOCKERHUB_USER}" ] || [ -z "${USE_DOCKER_BUILDX}" ] ; then
     echo ""
     echo "The following variables can be exported to access more functionality (See Descriptions)."
@@ -236,8 +278,25 @@ case $1 in
       list_minio_files
     ;;
 
+    retrieve-minio-files)
+      retrieve_minio_files
+    ;;
+
     copy-minio-files)
-      copy_minio_files
+      if [ -z "$2" ]; then
+        echo "Usage $0 <local_directory>"
+        exit 1
+      fi
+      if [ ! -d "$2" ]; then
+        echo "Given directory ${2} is not a directory"
+        exit 1
+      fi
+
+      copy_minio_files $2
+    ;;
+
+    reset-minio-bucket)
+      reset_minio_bucket
     ;;
 
     backup-restore)
@@ -252,12 +311,8 @@ case $1 in
       uninstall_charts
     ;;
 
-    help)
-      script-info
-    ;;
-
     *)
-      echo "Please use ./deploy help for more information on how to run the script"
+      script-info
     ;;
 
 esac


### PR DESCRIPTION
* Removes `./scripts/deploy help`, shortens it to `./scripts/deploy` for displaying info
* Refactored the `KUBECONFIG` check, if `~/.kube/config` is correct, the environment variable is not set but it can still work (like with k3d) so removed the explicit check for `KUBECONFIG`
* Renamed `copy-minio-files` to `retrieve-minio-files` so its clear its for retrieving from Minio
* Added `copy-minio-files` to copy local files to the Minio bucket
* Added `reset-minio-bucket` to delete and create the `rancherbackups` bucket