### PR TITLE
Update chart version constraints

### DIFF
--- a/charts/rancher-backup/Chart.yaml
+++ b/charts/rancher-backup/Chart.yaml
@@ -2,12 +2,12 @@ annotations:
   catalog.cattle.io/auto-install: rancher-backup-crd=match
   catalog.cattle.io/certified: rancher
   catalog.cattle.io/display-name: Rancher Backups
-  catalog.cattle.io/kube-version: '>= 1.16.0-0'
+  catalog.cattle.io/kube-version: '>= 1.16.0-0 < 1.25.0-0'
   catalog.cattle.io/namespace: cattle-resources-system
   catalog.cattle.io/os: linux
   catalog.cattle.io/permits-os: linux,windows
   catalog.cattle.io/provides-gvr: resources.cattle.io.resourceset/v1
-  catalog.cattle.io/rancher-version: '>=2.6.0-0'
+  catalog.cattle.io/rancher-version: '>= 2.6.0-0 < 2.7.0-0'
   catalog.cattle.io/release-name: rancher-backup
   catalog.cattle.io/scope: management
   catalog.cattle.io/type: cluster-tool


### PR DESCRIPTION
See https://github.com/rancher/charts/pull/1948#discussion_r903121177 and https://github.com/rancher/charts/pull/1948#discussion_r903121442

Also updated `kubeVersion` to match `catalog.cattle.io/kube-version`