### PR TITLE
Add basic integration for all architectures

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -17,12 +17,17 @@ RUN if [ "${ARCH}" != "s390x" ]; then \
         helm plugin install https://github.com/quintush/helm-unittest; \
     fi
 
-#integration tests only support amd64
-RUN if [ "${ARCH}" == "amd64" ]; then \
-        curl -sL https://github.com/rancher/k3s/releases/download/$(curl -Ls -o /dev/null -w %{url_effective} https://update.k3s.io/v1-release/channels/stable | awk -F/ '{ print $NF }')/k3s > /usr/local/bin/k3s \
-        && chmod +x /usr/local/bin/k3s \
-        && curl -sL https://dl.min.io/client/mc/release/linux-amd64/mc > /usr/local/bin/mc \
-        && chmod +x /usr/local/bin/mc; \
+ENV K3S_BINARY_amd64=k3s \
+    K3S_BINARY_arm64=k3s-arm64 \
+    K3S_BINARY_s390x=k3s-s390x \
+    K3S_BINARY=K3S_BINARY_${ARCH}
+
+RUN curl -sL https://github.com/rancher/k3s/releases/download/$(curl -Ls -o /dev/null -w %{url_effective} https://update.k3s.io/v1-release/channels/stable | awk -F/ '{ print $NF }')/${!K3S_BINARY} > /usr/local/bin/k3s && \
+    chmod +x /usr/local/bin/k3s
+
+RUN if [ "${ARCH}" != "s390x" ]; then \
+        curl -sL https://dl.min.io/client/mc/release/linux-${ARCH}/mc > /usr/local/bin/mc  && \
+        chmod +x /usr/local/bin/mc; \
     fi
 
 ENV DAPPER_ENV REPO TAG DRONE_TAG CROSS USE_DOCKER_BUILDX

--- a/scripts/integration
+++ b/scripts/integration
@@ -4,11 +4,6 @@ function echo_with_time {
     echo "$(date --utc +%Y-%m-%dT%H:%M:%SZ) "$@""
 }
 
-if [ "$ARCH" != "amd64" ]; then
-    echo_with_time "Integration test only run on amd64"
-    exit 0
-fi
-
 source $(dirname $0)/version
 
 echo_with_time "INFO - Running $0"
@@ -24,7 +19,7 @@ echo_with_time 'Waiting for node to be ready ...'
 time timeout 300 bash -c 'while ! (k3s kubectl wait --for condition=ready node/$(hostname) 2>/dev/null); do sleep 5; done'
 time timeout 300 bash -c 'while ! (k3s kubectl --namespace kube-system rollout status --timeout 10s deploy/coredns 2>/dev/null); do sleep 5; done'
 
-k3s kubectl get nodes -o wide
+k3s kubectl get nodes -o wide --show-labels
 
 docker image save rancher/backup-restore-operator:$TAG -o /tmp/bro.img
 
@@ -50,6 +45,12 @@ k3s kubectl get pods -n cattle-resources-system
 time timeout 300 bash -c 'while ! (k3s kubectl --namespace cattle-resources-system rollout status --timeout 10s deploy/rancher-backup 2>/dev/null); do sleep 5; done'
 
 k3s kubectl get pods -n cattle-resources-system
+
+# Minio not available for s390x, only test on amd64 and arm64
+if [ "$ARCH" = "s390x" ]; then
+    echo_with_time "Minio part of integration test only run on amd64 and arm64"
+    exit 0
+fi
 
 #Deploy Minio
 ./scripts/deploy minio


### PR DESCRIPTION
* Also runs integration tests for arm64 and s390x, as Minio is not available on s390x, we don't run those tests on s390x.