### PR TITLE
Excluding csp adapter resources from backup

### DIFF
--- a/charts/rancher-backup/files/default-resourceset-contents/rancher.yaml
+++ b/charts/rancher-backup/files/default-resourceset-contents/rancher.yaml
@@ -11,11 +11,11 @@
       - key: "owner"
         operator: "NotIn"
         values: ["helm"]
-  excludeResourceNameRegexp: "^bootstrap-secret$"
+  excludeResourceNameRegexp: "^bootstrap-secret$|^rancher-csp-adapter|^csp-adapter-cache$"
 - apiVersion: "v1"
   kindsRegexp: "^serviceaccounts$"
   namespaceRegexp: "^cattle-|^p-|^c-|^local$|^user-|^u-"
-  excludeResourceNameRegexp: "^default$"
+  excludeResourceNameRegexp: "^default$|^rancher-csp-adapter$"
 - apiVersion: "v1"
   kindsRegexp: "^configmaps$"
   namespaces:
@@ -23,12 +23,14 @@
 - apiVersion: "rbac.authorization.k8s.io/v1"
   kindsRegexp: "^roles$|^rolebindings$"
   namespaceRegexp: "^cattle-|^p-|^c-|^local$|^user-|^u-"
+  excludeResourceNameRegexp: "^rancher-csp-adapter"
 - apiVersion: "rbac.authorization.k8s.io/v1"
   kindsRegexp: "^clusterrolebindings$"
   resourceNameRegexp: "^cattle-|^clusterrolebinding-|^globaladmin-user-|^grb-u-|^crb-"
 - apiVersion: "rbac.authorization.k8s.io/v1"
   kindsRegexp: "^clusterroles$"
   resourceNameRegexp: "^cattle-|^p-|^c-|^local-|^user-|^u-|^project-|^create-ns$"
+  excludeResourceNameRegexp: "^rancher-csp-adapter-"
 - apiVersion: "apiextensions.k8s.io/v1"
   kindsRegexp: "."
   resourceNameRegexp: "management.cattle.io$|project.cattle.io$|catalog.cattle.io$|resources.cattle.io$"
@@ -36,6 +38,7 @@
   kindsRegexp: "."
   excludeKinds:
     - "tokens"
+    - "rancherusernotifications"
 - apiVersion: "management.cattle.io/v3"
   kindsRegexp: "^tokens$"
   labelSelectors:


### PR DESCRIPTION
Related to rancher/rancher#38365 . As part of the new work on the [csp adapter](https://github.com/rancher/csp-adapter), we need to exclude the resources of the adapter form the backup restore process. This is due to the fact that an adapter really only works for one cluster at a time, and it is a better user experience to have the user re-install the adapter rather than attempting to copy over the various resources during backup. This excludes the resources that were being copied over for the adapter. See https://github.com/rancher/rancher/issues/38365#issuecomment-1191965849 for a full listing of adapter resources which need to be excluded from this process.