### PR TITLE
Allow static pv to be correctly referenced.

### DIFF
--- a/charts/rancher-backup/templates/_helpers.tpl
+++ b/charts/rancher-backup/templates/_helpers.tpl
@@ -79,7 +79,7 @@ Create PVC name using release and revision number, unless a volumeName is given.
 */}}
 {{- define "backupRestore.pvcName" -}}
 {{- if and .Values.persistence.volumeName }}
-{{- printf "%s-pvc" .Values.persistence.volumeName }}
+{{- printf "%s" .Values.persistence.volumeName }}
 {{- else -}}
 {{- printf "%s-%d" .Release.Name .Release.Revision }}
 {{- end }}

--- a/charts/rancher-backup/templates/_helpers.tpl
+++ b/charts/rancher-backup/templates/_helpers.tpl
@@ -75,9 +75,13 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
-Create PVC name using release and revision number.
+Create PVC name using release and revision number, unless a volumeName is given.
 */}}
 {{- define "backupRestore.pvcName" -}}
+{{- if and .Values.persistence.volumeName }}
+{{- printf "%s-pvc" .Values.persistence.volumeName }}
+{{- else -}}
 {{- printf "%s-%d" .Release.Name .Release.Revision }}
+{{- end }}
 {{- end }}
 

--- a/charts/rancher-backup/tests/deployment_test.yaml
+++ b/charts/rancher-backup/tests/deployment_test.yaml
@@ -108,6 +108,21 @@ tests:
       path: spec.template.spec.volumes[0].persistentVolumeClaim
       value:
         claimName: RELEASE-NAME-0
+- it: should set claim name from custom volumeName
+  set:
+    persistence.enabled: true
+    persistence.volumeName: "predefined-volume"
+  template: deployment.yaml
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: DEFAULT_PERSISTENCE_ENABLED
+        value: "persistence-enabled"
+  - equal:
+      path: spec.template.spec.volumes[0].persistentVolumeClaim
+      value:
+        claimName: predefined-volume-pvc
 - it: should set private registry
   template: deployment.yaml
   set:

--- a/charts/rancher-backup/tests/deployment_test.yaml
+++ b/charts/rancher-backup/tests/deployment_test.yaml
@@ -124,7 +124,7 @@ tests:
   - equal:
       path: spec.template.spec.volumes[0].persistentVolumeClaim
       value:
-        claimName: PREDEFINED-VOLUME-pvc
+        claimName: PREDEFINED-VOLUME
 - it: should set private registry
   template: deployment.yaml
   set:

--- a/charts/rancher-backup/tests/deployment_test.yaml
+++ b/charts/rancher-backup/tests/deployment_test.yaml
@@ -108,10 +108,12 @@ tests:
       path: spec.template.spec.volumes[0].persistentVolumeClaim
       value:
         claimName: RELEASE-NAME-0
-- it: should set claim name from custom volumeName
+- it: should set claim from custom static volumeName
   set:
     persistence.enabled: true
-    persistence.volumeName: "predefined-volume"
+    persistence.volumeName: "PREDEFINED-VOLUME"
+    persistence.storageClass: "PREDEFINED-STORAGECLASS"
+    persistence.size: "PREDIFINED-SAMEAS-PVSIZE"
   template: deployment.yaml
   asserts:
   - contains:
@@ -122,7 +124,7 @@ tests:
   - equal:
       path: spec.template.spec.volumes[0].persistentVolumeClaim
       value:
-        claimName: predefined-volume-pvc
+        claimName: PREDEFINED-VOLUME-pvc
 - it: should set private registry
   template: deployment.yaml
   set:

--- a/charts/rancher-backup/tests/pvc_test.yaml
+++ b/charts/rancher-backup/tests/pvc_test.yaml
@@ -86,3 +86,20 @@ tests:
   - equal:
       path: spec.volumeName
       value: "volume-name"
+- it: should set claim from custom static volumeName
+  set:
+    persistence.enabled: true
+    persistence.volumeName: "PREDEFINED-VOLUME"
+    persistence.storageClass: "PREDEFINED-STORAGECLASS"
+    persistence.size: "PREDEFINED-SAMEAS-PVSIZE"
+  template: pvc.yaml
+  set:
+    persistence:
+      enabled: true
+  asserts:
+  - equal:
+      path: spec.resources.requests.storage
+      value: "PREDEFINED-SAMEAS-PVSIZE"
+  - equal:
+      path: spec.storageClassName
+      value: "PREDEFINED-STORAGECLASS"


### PR DESCRIPTION
Fix #94. The generated pvc name and the size must be passed as well for this to work