### PR TITLE
[release/v3.0] Use proper input for imagePullSecrets test

### DIFF
--- a/charts/rancher-backup/tests/deployment_test.yaml
+++ b/charts/rancher-backup/tests/deployment_test.yaml
@@ -190,9 +190,10 @@ tests:
       path: spec.template.spec.imagePullSecrets
 - it: should set imagePullSecrets
   set:
-    imagePullSecrets: [ 'pull-secret' ]
+    imagePullSecrets:
+    - name: "pull-secret"
   template: deployment.yaml
   asserts:
   - equal:
-      path: spec.template.spec.imagePullSecrets[0]
+      path: spec.template.spec.imagePullSecrets[0].name
       value: "pull-secret"


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/39291

The test was properly testing if the input resulted in the correct output, but its not what k8s expects how `imagePullSecrets` are set so corrected that in this PR.