### PR TITLE
Add ResourceSet definition for elemental

### DIFF
--- a/charts/rancher-backup/files/default-resourceset-contents/elemental.yaml
+++ b/charts/rancher-backup/files/default-resourceset-contents/elemental.yaml
@@ -1,0 +1,49 @@
+- apiVersion: "apiextensions.k8s.io/v1"
+  kindsRegexp: "."
+  resourceNameRegexp: "elemental.cattle.io$"
+- apiVersion: "apps/v1"
+  kindsRegexp: "^deployments$"
+  namespaces:
+    - "cattle-elemental-system"
+  resourceNames:
+    - "elemental-operator"
+- apiVersion: "rbac.authorization.k8s.io/v1"
+  kindsRegexp: "^clusterroles$"
+  resourceNames:
+    - "elemental-operator"
+- apiVersion: "rbac.authorization.k8s.io/v1"
+  kindsRegexp: "^clusterrolebindings$"
+  resourceNames:
+    - "elemental-operator"
+- apiVersion: "v1"
+  kindsRegexp: "^serviceaccounts$"
+  namespaces:
+    - "cattle-elemental-system"
+  resourceNames:
+    - "elemental-operator"
+- apiVersion: "management.cattle.io/v3"
+  kindsRegexp: "^globalrole$"
+  resourceNames:
+    - "elemental-operator"
+- apiVersion: "management.cattle.io/v3"
+  kindsRegexp: "^apiservice$"
+  resourceNameRegexp: "elemental.cattle.io$"
+- apiVersion: "elemental.cattle.io/v1beta1"
+  kindsRegexp: "."
+  namespaceRegexp: "^cattle-fleet-|^fleet-|^cluster-fleet-"
+- apiVersion: "rbac.authorization.k8s.io/v1"
+  kindsRegexp: "^roles$|^rolebindings$"
+  labelSelectors:
+    matchExpressions:
+    - key: "elemental.cattle.io/managed"
+      operator: "In"
+      values: ["true"]
+  namespaceRegexp: "^cattle-fleet-|^fleet-|^cluster-fleet-"
+- apiVersion: "v1"
+  kindsRegexp: "^secrets$|^serviceaccounts$"
+  labelSelectors:
+    matchExpressions:
+    - key: "elemental.cattle.io/managed"
+      operator: "In"
+      values: ["true"]
+  namespaceRegexp: "^cattle-fleet-|^fleet-|^cluster-fleet-"


### PR DESCRIPTION
We would like include elemental CRD resources and all object created by it to backup policy.

Fixes https://github.com/rancher/elemental-operator/issues/9