### PR TITLE
bumping dapper version to v0.6.0

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -8,7 +8,7 @@ platform:
 
 steps:
 - name: build
-  image: rancher/dapper:v0.4.1
+  image: rancher/dapper:v0.6.0
   commands:
   - export K8S_VERSION_FROM_DRONE="v1.24"
   - dapper ci
@@ -19,7 +19,7 @@ steps:
     no_cache: true
 
 - name: build_no_psp
-  image: rancher/dapper:v0.4.1
+  image: rancher/dapper:v0.6.0
   commands:
   - export K8S_VERSION_FROM_DRONE="stable"
   - dapper ci
@@ -127,7 +127,7 @@ platform:
 
 steps:
 - name: build
-  image: rancher/dapper:v0.4.1
+  image: rancher/dapper:v0.6.0
   commands:
   - export K8S_VERSION_FROM_DRONE="v1.24"
   - dapper ci
@@ -136,7 +136,7 @@ steps:
     path: /var/run/docker.sock
 
 - name: build_no_psp
-  image: rancher/dapper:v0.4.1
+  image: rancher/dapper:v0.6.0
   commands:
   - export K8S_VERSION_FROM_DRONE="stable"
   - dapper ci
@@ -226,7 +226,7 @@ node:
 
 steps:
   - name: build
-    image: rancher/dapper:v0.5.8
+    image: rancher/dapper:v0.6.0
     commands:
       - export K8S_VERSION_FROM_DRONE="v1.24"
       - dapper ci
@@ -235,7 +235,7 @@ steps:
         path: /var/run/docker.sock
 
   - name: build_no_psp
-    image: rancher/dapper:v0.5.8
+    image: rancher/dapper:v0.6.0
     commands:
     - export K8S_VERSION_FROM_DRONE="stable"
     - dapper ci


### PR DESCRIPTION
Bumping dapper version to fix issue with latest docker release.

[issue](https://github.com/rancher/backup-restore-operator/issues/299)