### PR TITLE
Revert "Updated machine-plan secret regex to capture new naming scheme"

### DIFF
--- a/charts/rancher-backup/files/default-resourceset-contents/provisioningv2.yaml
+++ b/charts/rancher-backup/files/default-resourceset-contents/provisioningv2.yaml
@@ -15,6 +15,6 @@
   kindsRegexp: "."
 - apiVersion: "v1"
   kindsRegexp: "^secrets$"
-  resourceNameRegexp: "machine-plan$|machine-plan-token$|rke-state$|machine-state$|machine-driver-secret$|machine-provision$|^harvesterconfig"
+  resourceNameRegexp: "machine-plan$|rke-state$|machine-state$|machine-driver-secret$|machine-provision$|^harvesterconfig"
   namespaces:
   - "fleet-default"


### PR DESCRIPTION
This reverts commit d607b8517db8f927b1777a38c3ecc2465c755c83.