### PR TITLE
add the configmap for provisioning logs to the default resource set

### DIFF
--- a/charts/rancher-backup/files/default-resourceset-contents/provisioningv2.yaml
+++ b/charts/rancher-backup/files/default-resourceset-contents/provisioningv2.yaml
@@ -18,3 +18,8 @@
   resourceNameRegexp: "machine-plan$|rke-state$|machine-state$|machine-driver-secret$|machine-provision$|^harvesterconfig"
   namespaces:
   - "fleet-default"
+- apiVersion: "v1"
+  kindsRegexp: "^configmaps$"
+  resourceNames:
+    - "provisioning-log"
+  namespaceRegexp: "^c-m-"


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/40580

**Problem:**
When provisioning an RKE2/K3s cluster in rancher, the provisioning logs are saved into a configmap named `provisioning-log` in the namespace name `c-m-xxxxxxx`. 
For example, we can find it in the local cluster:
```
> k -n c-m-qm2chjf7 get cm
NAME               DATA   AGE
kube-root-ca.crt   1      46m
provisioning-log   2      46m
```

This configmap is missing from the backup because the built-in resource set lacks the matching rule. 

**Solution:**

The fix is to add the missing rule to the resource set. 

**Tests:**

The fix is tested by doing the following:

- run rancher v2.7-head single-install, 
- install the `rancher-backup` app 102.0.0+up3.1.0-rc2 in the local cluster 
- create a node-driver downstream RKE2 cluster 
- create a backup in which set the `resourceSetName` to the builtin one named `rancher-resource-set` 
- confirm the comfigMap for provisioning logs does **not** exist in the backup tar file 
- clone the builtin resourceSet and add the new rule from this PR 
- create another backup in which set the `resourceSetName` to the clone 
- confirm the comfigMap for provisioning logs **exists** in the new backup tar file 