### PR TITLE
Exclude import-token secrets from fleet backups

### DIFF
--- a/charts/rancher-backup/files/default-resourceset-contents/fleet.yaml
+++ b/charts/rancher-backup/files/default-resourceset-contents/fleet.yaml
@@ -4,6 +4,7 @@
 - apiVersion: "v1"
   kindsRegexp: "^secrets$"
   namespaceRegexp: "^cattle-fleet-|^fleet-|^cluster-fleet-"
+  excludeResourceNameRegexp: "^import-token"
   labelSelectors:
     matchExpressions:
       - key: "owner"


### PR DESCRIPTION
Pertaining to the following github issues:

https://github.com/rancher/rancher/issues/40819
https://github.com/rancher/rancher/issues/40080
https://github.com/rancher/rancher/issues/40859

The operator has a temporary hotfix to ignore these keys upon restore. We should avoid backing them up in the first place.