### PR TITLE
Removing --helm3 tag from helm unittest

### DIFF
--- a/charts/rancher-backup/tests/pvc_test.yaml
+++ b/charts/rancher-backup/tests/pvc_test.yaml
@@ -93,9 +93,6 @@ tests:
     persistence.storageClass: "PREDEFINED-STORAGECLASS"
     persistence.size: "PREDEFINED-SAMEAS-PVSIZE"
   template: pvc.yaml
-  set:
-    persistence:
-      enabled: true
   asserts:
   - equal:
       path: spec.resources.requests.storage

--- a/scripts/chart/test
+++ b/scripts/chart/test
@@ -22,4 +22,4 @@ if [[ $? > 0 ]]; then
 fi
 
 
-HELM_PLUGINS=/root/.local/share/helm/plugins/ helm unittest --helm3 ../build/charts/rancher-backup
+HELM_PLUGINS=/root/.local/share/helm/plugins/ helm unittest ../build/charts/rancher-backup


### PR DESCRIPTION
Since helm2 ssupport was https://github.com/helm-unittest/helm-unittest/pull/114 plugin we use, we need to remove the --helm3 tag from the test call.