### PR TITLE
Adding customize case for cluster.management.cattle.io obj

### DIFF
--- a/pkg/controllers/restore/controller.go
+++ b/pkg/controllers/restore/controller.go
@@ -530,6 +530,11 @@ func customize(obj *unstructured.Unstructured) {
 			if err := unstructured.SetNestedField(obj.Object, int64(redeploySystemAgentGeneration+1), "spec", "redeploySystemAgentGeneration"); err != nil {
 				logrus.Warnf("Provisioning cluster %s/%s can't be reset to be re-imported, error: %v", obj.GetNamespace(), obj.GetName(), err)
 			}
+		case "management.cattle.io/v3":
+			//Set io.cattle.agent.force.deploy to true to force cattle-cluster-agent redeployment
+			annotations := obj.GetAnnotations()
+			annotations["io.cattle.agent.force.deploy"] = "true"
+			obj.SetAnnotations(annotations)
 		}
 	}
 }


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/41589
Based off fix suggested by @snasovich to set the io.cattle.agent.force.deploy="true" annotation on restored cluster objects to force system-agent redeployment.