### PR TITLE
Excluding bundle deployments from default resourceSet

### DIFF
--- a/charts/rancher-backup/files/default-resourceset-contents/fleet.yaml
+++ b/charts/rancher-backup/files/default-resourceset-contents/fleet.yaml
@@ -36,6 +36,8 @@
   resourceNameRegexp: "fleet.cattle.io$|gitjob.cattle.io$"
 - apiVersion: "fleet.cattle.io/v1alpha1"
   kindsRegexp: "."
+  excludeKinds:
+    - "bundledeployments"
 - apiVersion: "gitjob.cattle.io/v1"
   kindsRegexp: "."
 - apiVersion: "apps/v1"


### PR DESCRIPTION
This PR is being done in regards to testing done on backup restore v3.1.2-rc1. It was found that `bundledeployments` were being backed up and they are a `cluster-fleet-*` namespaced resource, so in alignment with the solution to https://github.com/rancher/rancher/issues/34518 they were excluded from the resourceSet.

### Testing environment
**1**
Rancher version: v2.7.7-rc4
Installation option (Docker install/Helm Chart): Helm chart
Kubernetes Version and Engine: v1.26.7-rancher1-1
Backup Restore Version: v102.0.2+up3.1.2-rc1 (with updated resourceSet)
**2**
Rancher version: v2.7.6
Installation option (Docker install/Helm Chart): Helm chart
Kubernetes Version and Engine: v1.24.16-rancher1-1
Backup Restore Version: v102.0.2+up3.1.2-rc1  (with updated resourceSet)

In the first test case the below errors did not appear:
```
Error restoring resource mcc-<redacted>-managed-system-upgrade-controller of type fleet.cattle.io/v1alpha1, Resource=bundledeployments: restoreResource: err creating resource namespaces "cluster-fleet-default-<redacted>" not found

Error restoring resource fleet-agent-local of type fleet.cattle.io/v1alpha1, Resource=bundledeployments: restoreResource: err creating resource namespaces "cluster-fleet-local-local-<redacted>" not found

Error restoring resource fleet-agent-<redacted> of type fleet.cattle.io/v1alpha1, Resource=bundledeployments: restoreResource: err creating resource namespaces "cluster-fleet-default-<redacted>" not found
```
However the [capi-webhook error](https://github.com/rancher/rancher/issues/42631) (below) was still present and were actually 7 individual related errors present in the full log.
```
Error restoring resource <redacted> of type cluster.x-k8s.io/v1alpha4, Resource=clusters: restoreResource: err creating resource conversion webhook for cluster.x-k8s.io/v1alpha4, Kind=Cluster failed: Post "[https://capi-webhook-service.cattle-provisioning-capi-system.svc:443/convert?timeout=30s](https://capi-webhook-service.cattle-provisioning-capi-system.svc/convert?timeout=30s)": service "capi-webhook-service" not found
```

Second case resulted in a successful migration but the [node alignment issue](https://github.com/rancher/rancher/issues/34518#issuecomment-1703263411) is present. It's fixable and has a workaround but I believe it is a byproduct of removing the bundledeployments. This state happens inconsistently but is fixable and there is a workaround in my linked comment on the parent issue. 