### PR TITLE
Removing v1alpha4 cluster resources from backup

### DIFF
--- a/charts/rancher-backup/files/default-resourceset-contents/provisioningv2.yaml
+++ b/charts/rancher-backup/files/default-resourceset-contents/provisioningv2.yaml
@@ -9,8 +9,6 @@
   kindsRegexp: "."
 - apiVersion: "rke.cattle.io/v1"
   kindsRegexp: "."
-- apiVersion: "cluster.x-k8s.io/v1alpha4"
-  kindsRegexp: "."
 - apiVersion: "cluster.x-k8s.io/v1beta1"
   kindsRegexp: "."
 - apiVersion: "v1"


### PR DESCRIPTION
## Issue
https://github.com/rancher/rancher/issues/42631

## Change
Removing the below code block from the default resourceSet:
```
- apiVersion: "cluster.x-k8s.io/v1alpha4"
  kindsRegexp: "."
```

## Explanation
These resources should not be backed up and this selector was left in the default resourceSet after the new apiVersion was added in [this commit](https://github.com/rancher/backup-restore-operator/blame/release/v3.0/charts/rancher-backup/files/default-resourceset-contents/provisioningv2.yaml#:~:text=last%20year-,Add%20v1beta1%20CAPI%20objects,-14). It is not clear why.

It looks like because these resources were left included in the backup, it became a silent issue until the capi-webhook changes led to conversion webhooks being called. It seems that the conversion webhooks were not running correctly ([due to this line](https://github.com/rancher/rancher/pull/42228/files#diff-50571984e458c5ba494e0f1171749130921e527a093ab70258feb080eb565877L280)) until the most recent version of rancher and this is why we only ran into the error now. 

By removing these unnecessary resources from the backup the error is fixed because they are not there to call the conversion webhooks which are now active, effectively solving the errors in the restore.

## Testing considerations
Normal P0 test cases, mainly migrations with RKE2 and RKE1 downstream clusters, are all that need to be run to test this.
