### PR TITLE
Fixing manifest drone step

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -233,7 +233,6 @@ steps:
     platforms:
       - linux/amd64
       - linux/arm64
-      - linux/s390x
     target: "rancher/backup-restore-operator:${DRONE_TAG}"
     template: "rancher/backup-restore-operator:${DRONE_TAG}-ARCH"
   when:

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -19,7 +19,6 @@ RUN if [ "${ARCH}" != "s390x" ]; then \
 
 ENV K3S_BINARY_amd64=k3s \
     K3S_BINARY_arm64=k3s-arm64 \
-    K3S_BINARY_s390x=k3s-s390x \
     K3S_BINARY=K3S_BINARY_${ARCH}
 
 ARG K8S_VERSION_FROM_DRONE


### PR DESCRIPTION
Drone is still trying to verify `s390x` images in the manifest step. Removing it in this PR.