### PR TITLE
Update Rancher Version Annotation

### DIFF
--- a/charts/rancher-backup/Chart.yaml
+++ b/charts/rancher-backup/Chart.yaml
@@ -7,12 +7,12 @@ annotations:
   catalog.cattle.io/os: linux
   catalog.cattle.io/permits-os: linux,windows
   catalog.cattle.io/provides-gvr: resources.cattle.io.resourceset/v1
-  catalog.cattle.io/rancher-version: '>= 2.7.0-0 < 2.8.0-0'
+  catalog.cattle.io/rancher-version: '>= 2.9.0-0 < 2.10.0-0'
   catalog.cattle.io/release-name: rancher-backup
   catalog.cattle.io/scope: management
   catalog.cattle.io/type: cluster-tool
   catalog.cattle.io/ui-component: rancher-backup
-  catalog.cattle.io/upstream-version: 2.1.1
+  catalog.cattle.io/upstream-version: 5.0.0
 apiVersion: v2
 appVersion: 999
 description: Provides ability to back up and restore the Rancher application running


### PR DESCRIPTION
> change the rancher-version annotation to `[catalog.cattle.io/rancher-version](http://catalog.cattle.io/rancher-version): '>= 2.9.0-0 < 2.10.0-0'` (preferred) or  `[catalog.cattle.io/rancher-version](http://catalog.cattle.io/rancher-version): '>= 2.9.0-0'` while adding charts to dev-v2.9 branch.