### PR TITLE
Changed filter logic for include and exclude resource

### DIFF
--- a/pkg/resourcesets/collector.go
+++ b/pkg/resourcesets/collector.go
@@ -259,9 +259,9 @@ func (h *ResourceHandler) filterByNameAndLabel(ctx context.Context, dr dynamic.R
 
 	// filter out using ExcludeResourceNameRegexp
 	if filter.ExcludeResourceNameRegexp != "" {
-                if filter.ResourceNameRegexp == "" {
-                       filteredByName = resourceObjectsList.Items
-                }
+		if filter.ResourceNameRegexp == "" {
+			filteredByName = resourceObjectsList.Items
+		}
 		var newFilteredByName []unstructured.Unstructured
 		for _, resObj := range filteredByName {
 			metadata := resObj.Object["metadata"].(map[string]interface{})


### PR DESCRIPTION
Moved ExcludeResourceNameRegexp check in the same if block as ResourceNameRegexp This is to make it so ExcludeResourceNameRegexp does not causes previous check to be ignored