### PR TITLE
Refactor some of the resource-filterers

### DIFF
--- a/scripts/deploy
+++ b/scripts/deploy
@@ -83,7 +83,7 @@ list_minio_files() {
   fi
 
   docker run --rm --net=host -e MC_HOST_miniolocal=https://inspectorgadget:gogadgetgo@${DOCKER_HOSTNAME}:9000 minio/mc ls --insecure miniolocal/rancherbackups
-  kill -9 "$(pgrep -f "kubectl port-forward minio")"
+  kill -9 "$(pgrep -f "kubectl.*port-forward.*minio")"
 }
 
 retrieve_minio_files() {
@@ -108,7 +108,7 @@ retrieve_minio_files() {
   mkdir $MINIO_FILES_DIR
 
   docker run --rm --net=host -v "${PWD}/${MINIO_FILES_DIR}":/data -e MC_HOST_miniolocal=https://inspectorgadget:gogadgetgo@${DOCKER_HOSTNAME}:9000 minio/mc cp --insecure --recursive miniolocal/rancherbackups/ /data/
-  kill -9 "$(pgrep -f "kubectl port-forward minio")"
+  kill -9 "$(pgrep -f "kubectl.*port-forward.*minio")"
 
   echo "Copied all files from Minio to ./${MINIO_FILES_DIR}"
 }
@@ -135,7 +135,7 @@ copy_minio_files() {
   echo "Copying from directory ${SOURCE_FILES_DIR}"
 
   docker run --rm --net=host -v "${PWD}/${SOURCE_FILES_DIR}":/data -e MC_HOST_miniolocal=https://inspectorgadget:gogadgetgo@${DOCKER_HOSTNAME}:9000 minio/mc cp --insecure --recursive /data/ miniolocal/rancherbackups/
-  kill -9 "$(pgrep -f "kubectl port-forward minio")"
+  kill -9 "$(pgrep -f "kubectl.*port-forward.*minio")"
 
   echo "Copied all files from directory ${SOURCE_FILES_DIR} to Minio"
 }
@@ -160,7 +160,7 @@ reset_minio_bucket() {
 
   docker run --rm --net=host -e MC_HOST_miniolocal=https://inspectorgadget:gogadgetgo@${DOCKER_HOSTNAME}:9000 minio/mc rb --insecure --force miniolocal/rancherbackups
   docker run --rm --net=host -e MC_HOST_miniolocal=https://inspectorgadget:gogadgetgo@${DOCKER_HOSTNAME}:9000 minio/mc mb --insecure miniolocal/rancherbackups
-  kill -9 "$(pgrep -f "kubectl port-forward minio")"
+  kill -9 "$(pgrep -f "kubectl.*port-forward.*minio")"
 
   echo "Deleted and created the 'rancherbackups' bucket"
 }

--- a/tests/stubs/TestFilterByKind_CheckDuplicates.yaml
+++ b/tests/stubs/TestFilterByKind_CheckDuplicates.yaml
@@ -1,0 +1,55 @@
+---
+apiVersion: v1
+kind: Movie
+metadata:
+  name: V for Vendetta
+  namespace: sony
+# The code uses the same regexp to match both x.kind and x.name
+---
+apiVersion: v1
+kind: Movie
+metadata:
+  name: "The Godfather: Part II"
+  namespace: sony
+---
+apiVersion: v1
+kind: Movie
+metadata:
+  name: Dial M for Murder
+  namespace: united-artists
+---
+apiVersion: v1
+kind: Music
+metadata:
+  name: The Bodyguard
+  namespace: electra
+---
+apiVersion: v1
+kind: Music
+metadata:
+  name: Breakfast in America
+  namespace: reprise
+---
+apiVersion: v1
+kind: Music
+metadata:
+  name: Live at Bedrock
+  namespace: reprise
+---
+apiVersion: v1
+kind: Music
+metadata:
+  name: Brothers in Arms
+  namespace: warner
+---
+apiVersion: v1
+kind: Coffee
+metadata:
+  name: Antioquia
+  namespace: Strong Town
+---
+apiVersion: v1
+kind: Coffee
+metadata:
+  name: Boyaca
+  namespace: Joe Been


### PR DESCRIPTION
Fixes issue #411 

The `ResourceName`, `Namespace` and `Kind` filters all seemed somewhat clunky,  not to mention that 
they were the source of a recent bug. This PR changes them to standard filters, where you loop through the
array of source-objects and return an array of acceptable objects. 

I also precompile non-empty regular expressions, so we don't need to check for an error condition while
doing pattern-matching, making the actual filters follow a functional-programming paradigm, which in general
filters should try for.

Benchmarks showed a slight increase in performance. Running unit tests with `-count 10000`, the 
before run took 19.0 sec, the after 17.7. Note that this benchmark was done before the `TestFilterByKind_CheckDuplicates` was added, so comparisons are no longer valid. 