### PR TITLE
Fix Cross-Arch builds on arm64

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -63,7 +63,10 @@ If you want to interact with the Minio deployed in the cluster, you can use the 
 
 ### Building on Different Architectures
 
-Currently we only support building this chart for amd64 nodes. The binary built by `make build` is set to build for amd64 and we have also included a flag for users running different architectures when trying to package the code into a docker image. Setting `USE_DOCKER_BUILDX=1` will force the package script to use docker buildx, setting the target platform to build for amd64. If you do not have `docker-buildx` installed please reference [this page](https://docs.docker.com/buildx/working-with-buildx/).
+Currently, we only support building this chart fully for `amd64` nodes. The binary and image building scripts will build "arch native" by default.
+So when building on `amd64` the resulting binary and image will both be `amd64` - same for `arm64`. This is how the drone builds operate.
+
+We have also included a flag for users running different architectures when trying to package the code into an `amd64` docker image. Building the binary with `CROSS_ARCH=true` set will cause it to build `amd64` and `arm64` binaries, and then setting `USE_DOCKER_BUILDX=1` will force the package script to use docker buildx, setting the container's target platform to build for `amd64`. If you do not have `docker-buildx` installed please reference [this page](https://docs.docker.com/buildx/working-with-buildx/).
 
 
 ### Developer Uninstallation

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -38,7 +38,7 @@ RUN if [ "${ARCH}" != "s390x" ]; then \
         chmod +x /usr/local/bin/mc; \
     fi
 
-ENV DAPPER_ENV REPO TAG DRONE_TAG CROSS USE_DOCKER_BUILDX
+ENV DAPPER_ENV REPO TAG DRONE_TAG CROSS CROSS_ARCH USE_DOCKER_BUILDX
 ENV DAPPER_SOURCE /go/src/github.com/rancher/backup-restore-operator/
 ENV DAPPER_OUTPUT ./bin ./dist
 ENV GOCACHE /root/.cache/go-build

--- a/scripts/build
+++ b/scripts/build
@@ -13,17 +13,28 @@ LINKFLAGS="-X main.Version=$VERSION"
 LINKFLAGS="-X main.GitCommit=$COMMIT $LINKFLAGS"
 if [ "$CROSS_ARCH" != "true" ]; then
   CGO_ENABLED=0 go build -ldflags "$LINKFLAGS $OTHER_LINKFLAGS" -o bin/backup-restore-operator
-  if [ "$CROSS" = "true" ] && [ "$ARCH" = "amd64" ]; then
+  if [ "$CROSS" = "true" ]; then
     GOOS=darwin go build -ldflags "$LINKFLAGS" -o bin/backup-restore-operator-darwin
     GOOS=windows go build -ldflags "$LINKFLAGS" -o bin/backup-restore-operator-windows
   fi
 else
-  GOARCH=amd64 CGO_ENABLED=0 go build -ldflags "$LINKFLAGS $OTHER_LINKFLAGS" -o bin/backup-restore-operator
-  CGO_ENABLED=0 go build -ldflags "$LINKFLAGS $OTHER_LINKFLAGS" -o "bin/backup-restore-operator$SUFFIX"
-  if [ "$CROSS" = "true" ]; then
-    GOARCH=amd64 GOOS=darwin go build -ldflags "$LINKFLAGS" -o bin/backup-restore-operator-darwin
-    GOOS=darwin go build -ldflags "$LINKFLAGS" -o "bin/backup-restore-operator-darwin$SUFFIX"
-    GOARCH=amd64 GOOS=windows go build -ldflags "$LINKFLAGS" -o bin/backup-restore-operator-windows
-    GOOS=windows go build -ldflags "$LINKFLAGS" -o "bin/backup-restore-operator-windows$SUFFIX"
+  if [ "$ARCH" = "amd64" ]; then
+    CGO_ENABLED=0 go build -ldflags "$LINKFLAGS $OTHER_LINKFLAGS" -o bin/backup-restore-operator
+    GOARCH=arm64 CGO_ENABLED=0 go build -ldflags "$LINKFLAGS $OTHER_LINKFLAGS" -o bin/backup-restore-operator-arm64
+    if [ "$CROSS" = "true" ]; then
+      GOOS=darwin go build -ldflags "$LINKFLAGS" -o bin/backup-restore-operator-darwin
+      GOARCH=arm64 GOOS=darwin go build -ldflags "$LINKFLAGS" -o bin/backup-restore-operator-darwin-arm64
+      GOOS=windows go build -ldflags "$LINKFLAGS" -o bin/backup-restore-operator-windows
+      GOARCH=arm64 GOOS=windows go build -ldflags "$LINKFLAGS" -o bin/backup-restore-operator-windows-arm64
+    fi
+  else
+    CGO_ENABLED=0 go build -ldflags "$LINKFLAGS $OTHER_LINKFLAGS" -o "bin/backup-restore-operator$SUFFIX"
+    GOARCH=amd64 CGO_ENABLED=0 go build -ldflags "$LINKFLAGS $OTHER_LINKFLAGS" -o bin/backup-restore-operator
+    if [ "$CROSS" = "true" ]; then
+      GOOS=darwin go build -ldflags "$LINKFLAGS" -o "bin/backup-restore-operator-darwin$SUFFIX"
+      GOARCH=amd64 GOOS=darwin go build -ldflags "$LINKFLAGS" -o bin/backup-restore-operator-darwin
+      GOOS=windows go build -ldflags "$LINKFLAGS" -o "bin/backup-restore-operator-windows$SUFFIX"
+      GOARCH=amd64 GOOS=windows go build -ldflags "$LINKFLAGS" -o bin/backup-restore-operator-windows
+    fi
   fi
 fi

--- a/scripts/build
+++ b/scripts/build
@@ -11,8 +11,19 @@ if [ "$(uname)" = "Linux" ]; then
 fi
 LINKFLAGS="-X main.Version=$VERSION"
 LINKFLAGS="-X main.GitCommit=$COMMIT $LINKFLAGS"
-CGO_ENABLED=0 go build -ldflags "$LINKFLAGS $OTHER_LINKFLAGS" -o bin/backup-restore-operator
-if [ "$CROSS" = "true" ] && [ "$ARCH" = "amd64" ]; then
+if [ "$CROSS_ARCH" != "true" ]; then
+  CGO_ENABLED=0 go build -ldflags "$LINKFLAGS $OTHER_LINKFLAGS" -o bin/backup-restore-operator
+  if [ "$CROSS" = "true" ] && [ "$ARCH" = "amd64" ]; then
     GOOS=darwin go build -ldflags "$LINKFLAGS" -o bin/backup-restore-operator-darwin
     GOOS=windows go build -ldflags "$LINKFLAGS" -o bin/backup-restore-operator-windows
+  fi
+else
+  GOARCH=amd64 CGO_ENABLED=0 go build -ldflags "$LINKFLAGS $OTHER_LINKFLAGS" -o bin/backup-restore-operator
+  CGO_ENABLED=0 go build -ldflags "$LINKFLAGS $OTHER_LINKFLAGS" -o "bin/backup-restore-operator$SUFFIX"
+  if [ "$CROSS" = "true" ]; then
+    GOARCH=amd64 GOOS=darwin go build -ldflags "$LINKFLAGS" -o bin/backup-restore-operator-darwin
+    GOOS=darwin go build -ldflags "$LINKFLAGS" -o "bin/backup-restore-operator-darwin$SUFFIX"
+    GOARCH=amd64 GOOS=windows go build -ldflags "$LINKFLAGS" -o bin/backup-restore-operator-windows
+    GOOS=windows go build -ldflags "$LINKFLAGS" -o "bin/backup-restore-operator-windows$SUFFIX"
+  fi
 fi

--- a/scripts/package
+++ b/scripts/package
@@ -6,7 +6,11 @@ source $(dirname $0)/version
 cd $(dirname $0)/..
 
 mkdir -p dist/artifacts
-cp bin/backup-restore-operator dist/artifacts/backup-restore-operator${SUFFIX}
+if [ "$CROSS_ARCH" != "true" ]; then
+  cp bin/backup-restore-operator dist/artifacts/backup-restore-operator${SUFFIX}
+else
+  cp bin/backup-restore-operator${SUFFIX} dist/artifacts/
+fi
 
 IMAGE=${REPO}/backup-restore-operator:${TAG}
 DOCKERFILE=package/Dockerfile


### PR DESCRIPTION
Currently on an arm64 based system the binary will be arm64.
Then when the package script is run, it copies that arm64 binary into the image.
This is as expected when building native arm64/amd64 binaries and images.

However, when trying to build cross compiled binaries and images locally it falls apart.
So using `USE_DOCKER_BUILDX=1` locally the container image will end up amd64, but the binary inside arm64.
This PR is trying to work out the most simple way to fix that local build issue without affecting the results of drone or release builds.

To do this we add a new `CROSS_ARCH` build flag meant for local dev needing this functionality.
So running either `CROSS_ARCH=true make`, or `CROSS_ARCH=true make {SCRIPT}` will adjust for that use-case.