### PR TITLE
[release/v3.0] Fix the branches on renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,7 +3,9 @@
     "github>rancher/renovate-config#release"
   ],
   "baseBranches": [
-    "release/v3.0"
+    "release/v3.0",
+    "release/v4.0",
+    "release/v5.0"
   ],
   "prHourlyLimit": 2
 }


### PR DESCRIPTION
After reading docs for renovate config I realized the config should be uniform across active branches. So I'm adding all 3 versions to the v3 branch config first. Then these can be cherry-picked/merged up to v4 and v5 as desired.