### PR TITLE
Add upstream-version to release workflows

### DIFF
--- a/charts/rancher-backup/Chart.yaml
+++ b/charts/rancher-backup/Chart.yaml
@@ -12,7 +12,7 @@ annotations:
   catalog.cattle.io/scope: management
   catalog.cattle.io/type: cluster-tool
   catalog.cattle.io/ui-component: rancher-backup
-  catalog.cattle.io/upstream-version: 3.1.3
+  catalog.cattle.io/upstream-version: 999
 apiVersion: v2
 appVersion: 999
 description: Provides ability to back up and restore the Rancher application running

--- a/scripts/package-helm
+++ b/scripts/package-helm
@@ -5,6 +5,7 @@ function edit-charts() {
     sed -i \
         -e 's/^version:.*/version: '${1}'/' \
         -e 's/^appVersion:.*/appVersion: '${1}'/' \
+        -e 's/catalog.cattle.io\/upstream-version:.*/catalog.cattle.io\/upstream-version: '${1}'/' \
         build/charts/rancher-backup/Chart.yaml
 
     sed -i \


### PR DESCRIPTION
This is a small improvement I think should be in all the active branches. And while in the future we'll probably work from newer-backwards, right now we're still in a place where starting here makes sense to me.

Since I have plans to create subsequent syncing PRs up from 3->4->5 in order to properly catch all the changes 3.x branch has currently. This should both help address the renovate situation and to address #411 