### PR TITLE
Switch to manual renovate runs and remove PR limit

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,7 @@
 {
   "extends": [
-    "github>rancher/renovate-config#release"
+    "github>rancher/renovate-config#release",
+    "group:all"
   ],
   "baseBranches": [
     "release/v3.0",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,6 +6,5 @@
     "release/v3.0",
     "release/v4.0",
     "release/v5.0"
-  ],
-  "prHourlyLimit": 2
+  ]
 }

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -13,8 +13,8 @@ on:
         default: "false"
         type: string
   # Run twice in the early morning (UTC) for initial and follow up steps (create pull request and merge)
-  schedule:
-    - cron: '30 4,6 * * *'
+  # schedule:
+  #   - cron: '30 4,6 * * *'
 
 jobs:
   call-workflow:


### PR DESCRIPTION
Making automating dependency bumps temporarily easier.