### PR TITLE
fix typo in local ref for CI actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,7 @@ permissions:
   contents : read
 
 on:
+  workflow_call:
   push:
     branches:
       - release/v5.0

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   ci :
-    uses: rancher/backup-restore/.github/workflows/ci.yaml@release/v5.0
+    uses: rancher/backup-restore-operator/.github/workflows/ci.yaml@release/v5.0
     permissions:
       contents: read
   push:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   ci:
-    uses: rancher/backup-restore/.github/workflows/ci.yaml@release/v5.0
+    uses: rancher/backup-restore-operator/.github/workflows/ci.yaml@release/v5.0
   goreleaser:
     needs: [
       ci

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,6 +11,8 @@ permissions:
 jobs:
   ci:
     uses: rancher/backup-restore-operator/.github/workflows/ci.yaml@release/v5.0
+    permissions:
+      contents: read
   goreleaser:
     needs: [
       ci


### PR DESCRIPTION
- embedded job did not point to the correct path
- embedded job was not callable without `workflow_call`