### PR TITLE
Adjust Renovate Rules

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,6 +3,20 @@
     "github>rancher/renovate-config#release",
     "group:all"
   ],
+  "packageRules": [
+    {
+      "packageNames": [
+        "github.com/rancher/hull",
+        "github.com/rancher/lasso",
+        "github.com/rancher/wrangler/v2"
+      ],
+      "enabled": false,
+      "branches": [
+        "release/v3.0",
+        "release/v4.0"
+      ]
+    }
+  ],
   "baseBranches": [
     "release/v3.0",
     "release/v4.0",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,6 +11,8 @@
   "ignoreDeps": [
     "github.com/rancher/hull",
     "github.com/rancher/lasso",
-    "github.com/rancher/wrangler/v2"
+    "github.com/rancher/wrangler",
+    "github.com/rancher/wrangler/v2",
+    "github.com/rancher/wrangler/v3"
   ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,23 +3,14 @@
     "github>rancher/renovate-config#release",
     "group:all"
   ],
-  "packageRules": [
-    {
-      "packageNames": [
-        "github.com/rancher/hull",
-        "github.com/rancher/lasso",
-        "github.com/rancher/wrangler/v2"
-      ],
-      "enabled": false,
-      "branches": [
-        "release/v3.0",
-        "release/v4.0"
-      ]
-    }
-  ],
   "baseBranches": [
     "release/v3.0",
     "release/v4.0",
     "release/v5.0"
+  ],
+  "ignoreDeps": [
+    "github.com/rancher/hull",
+    "github.com/rancher/lasso",
+    "github.com/rancher/wrangler/v2"
   ]
 }


### PR DESCRIPTION
This PR adds a few Rancher modules as global ignores across all branches. This will hopefully prevent the renovate PRs from causing as many breaking changes. Often when those modules are updated they need code generation to run too which is not currently part of Renovate tasks.

~This PR attempts to address the way that the 3.x and 4.x branch must keep K8S support to match their rancher versions. Essentially when the auto bump affects these packages (which are not versioned) the result is bumping peers (`k8s.io` items) that these branches of BRO cannot increase without causing breaking changes.~

Example Open PRs Causing issues:
https://github.com/rancher/backup-restore-operator/pull/461
https://github.com/rancher/backup-restore-operator/pull/462

And here's an example of what it takes to get these types of PRs mergable:
https://github.com/rancher/backup-restore-operator/pull/458
https://github.com/rancher/backup-restore-operator/pull/459