### PR TITLE
update CI k8s version support, based on rancher support matrix

### DIFF
--- a/.github/workflows/scripts/supported-versions.sh
+++ b/.github/workflows/scripts/supported-versions.sh
@@ -7,15 +7,15 @@ set -x
 
 if git merge-base --is-ancestor origin/release/v5.0 HEAD
 then
-  echo -n "[\"v1.23.9-k3s1\", \"v1.29.3-k3s1\"]"
+  printf '["%s", "%s"]' v1.23.9-k3s1 v1.29.4-k3s1
   exit 0
 elif git merge-base --is-ancestor origin/release/v4.0 HEAD
 then
-  echo -n "[\"v1.23.9-k3s1\", \"v1.28.8-k3s1\"]"
+  printf '["%s", "%s"]' v1.25.9-k3s1 v1.28.8-k3s1
   exit 0
 elif git merge-base --is-ancestor origin/release/v3.0 HEAD
 then
-  echo -n "[\"v1.16.9-k3s1\", \"v1.27.9-k3s1\"]"
+  printf '["%s", "%s"]' v1.23.9-k3s1 v1.27.9-k3s1
   exit 0
 fi
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,8 +1,6 @@
-# This is an example .goreleaser.yml file with some sensible defaults.
 # Make sure to check the documentation at https://goreleaser.com
 before:
   hooks:
-    # You may remove this if you don't use go modules.
     - go mod tidy
 builds:
     - id: backup-restore-operator
@@ -39,8 +37,3 @@ changelog:
     exclude:
       - '^docs:'
       - '^test:'
-
-# The lines beneath this are called `modelines`. See `:help modeline`
-# Feel free to remove those if you don't want/use them.
-# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
-# vim: set ts=2 sw=2 tw=0 fo=cnqoj

--- a/scripts/hull
+++ b/scripts/hull
@@ -18,6 +18,6 @@ cd $(dirname $0)/..
 
 cd tests
 echo "Running Hull Tests on Chart Version: $CHART_VERSION"
-go test -timeout 30s -run ^TestChart$ github.com/rancher/backup-restore-operator/tests/hull
+go test -race -timeout 30s -run ^TestChart$ github.com/rancher/backup-restore-operator/tests/hull
 
 cd ..

--- a/scripts/package-helm
+++ b/scripts/package-helm
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -e
 
+
 function edit-charts() {
     sed -i \
         -e 's/^version:.*/version: '${1}'/' \
@@ -29,7 +30,8 @@ if ! hash helm 2>/dev/null; then
 fi
 
 cd $(dirname $0)/..
-. ./scripts/version
+source ./scripts/version
+
 
 rm -rf build/charts
 mkdir -p build dist/artifacts


### PR DESCRIPTION
- Bump `release/v5.0` max support to `1.29.4`
- Bump minimum support to `1.25.X` for 2.8.X based on https://www.suse.com/suse-rancher/support-matrix/all-supported-versions/rancher-v2-8-1/
- Bump minimum support to `1.23.X` for 2.7.X based on https://www.suse.com/suse-rancher/support-matrix/all-supported-versions/rancher-v2-7-9/