### PR TITLE
Add packaged release charts to github releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,6 +26,9 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: 1.22
+      - name : Package release helm charts
+        run : make package-helm
+      - run : mkdir -p ./build/artifacts/ && mv -v ./dist/artifacts/ ./build/
       - uses: goreleaser/goreleaser-action@v5
         with:
           distribution: goreleaser

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /.cache
 /bin
 /dist
+/build
 *.swp
 .idea
 ./backup

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -7,8 +7,6 @@ builds:
       main: ./main.go
       goos:
         - linux
-        - darwin
-        - windows
       goarch:
         - amd64
         - arm64
@@ -26,7 +24,11 @@ archives:
     - id: backup-restore-operator
       builds:
         - backup-restore-operator 
-      name_template: '{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}'
+      name_template: '{{ .Binary }}-{{ .Arch }}'
+release:
+  prerelease: auto
+  extra_files:
+    - glob : ./build/artifacts/*.tgz
 checksum:
   name_template: 'checksums.txt'
 snapshot:


### PR DESCRIPTION
Fixes : https://github.com/rancher/backup-restore-operator/issues/474
- [x] Add packaged release charts to github releases
- [x] Compile release binaries only for linux amd & arm
- [x] Change release binary name format to match previous one

See : 
https://github.com/alexandreLamarre/backup-restore-operator/releases/tag/v5.0.0-rc.3

Note : name template is not updated in my fork to produce the same binary names, trying to save on my personal CI minutes, but the PR has the correct name changes.

## Testing

### Releases

Ran the action against my fork. Downloaded the release charts, and verified the images were set correctly -- feel free to download them yourselves to verify everything is in order.

### rancher/charts

Successfully ran `PACKAGE=rancher-backup make prepare` with 

`packages/rancher-backup/rancher-backup/package.yaml` :

```yaml
url: https://github.com/alexandreLamarre/backup-restore-operator/releases/download/v5.0.0-rc.3/rancher-backup-5.0.0-rc.3.tgz
version: 104.0.0
```

`packages/rancher-backup/rancher-backup-crd/package.yaml` :

```yaml
url: https://github.com/alexandreLamarre/backup-restore-operator/releases/download/v5.0.0-rc.3/rancher-backup-crd-5.0.0-rc.3.tgz
``` 

As a follow up, ran `PACKAGE=rancher-backup make charts`, and verified new versions were updated correctly in both `charts/` and `index.yaml`

For completeness, `index.yaml` diff:

```
diff --git a/index.yaml b/index.yaml
index 8771185fd..e6605b595 100755
--- a/index.yaml
+++ b/index.yaml
@@ -8022,7 +8022,7 @@ entries:
       catalog.cattle.io/auto-install: rancher-backup-crd=match
       catalog.cattle.io/certified: rancher
       catalog.cattle.io/display-name: Rancher Backups
-      catalog.cattle.io/kube-version: '>= 1.23.0-0 < 1.29.0-0'
+      catalog.cattle.io/kube-version: '>= 1.23.0-0 < 1.30.0-0'
       catalog.cattle.io/namespace: cattle-resources-system
       catalog.cattle.io/os: linux
       catalog.cattle.io/permits-os: linux,windows
@@ -8032,13 +8032,13 @@ entries:
       catalog.cattle.io/scope: management
       catalog.cattle.io/type: cluster-tool
       catalog.cattle.io/ui-component: rancher-backup
-      catalog.cattle.io/upstream-version: 5.0.0
+      catalog.cattle.io/upstream-version: 5.0.0-rc.3
     apiVersion: v2
-    appVersion: 5.0.0-rc2
-    created: "2024-01-11T15:05:21.187158-05:00"
+    appVersion: 5.0.0-rc.3
+    created: "2024-05-14T10:55:14.18407567-04:00"
     description: Provides ability to back up and restore the Rancher application running
       on any Kubernetes cluster
-    digest: 9f67c189f0ad41fad23c2a8f0b6d6373103738c0f20ccfdaf51010629c2f8b39
+    digest: c6da2dbfb7020ab10e735f723dda28fe7254b3a5834fb07fa58a3582cd88cb89
     icon: https://charts.rancher.io/assets/logos/backup-restore.svg
     keywords:
     - applications
@@ -8046,8 +8046,8 @@ entries:
     kubeVersion: '>= 1.23.0-0'
     name: rancher-backup
     urls:
-    - assets/rancher-backup/rancher-backup-104.0.0+up5.0.0-rc2.tgz
-    version: 104.0.0+up5.0.0-rc2
+    - assets/rancher-backup/rancher-backup-104.0.0+up5.0.0-rc.3.tgz
+    version: 104.0.0+up5.0.0-rc.3
   - annotations:
       catalog.cattle.io/auto-install: rancher-backup-crd=match
       catalog.cattle.io/certified: rancher
@@ -8672,15 +8672,15 @@ entries:
       catalog.cattle.io/namespace: cattle-resources-system
       catalog.cattle.io/release-name: rancher-backup-crd
     apiVersion: v2
-    appVersion: 5.0.0-rc2
-    created: "2024-01-10T17:07:40.545075-05:00"
+    appVersion: 5.0.0-rc.3
+    created: "2024-05-14T10:55:15.613690512-04:00"
     description: Installs the CRDs for rancher-backup.
-    digest: 3289fcf15eab70869e1871c8ab10a779f287c68483827bc253f686afbd56658b
+    digest: cca91de45eaf6d66584662fd4f05761708c447a49366141bb6f4aae4834d6753
     name: rancher-backup-crd
     type: application
     urls:
-    - assets/rancher-backup-crd/rancher-backup-crd-104.0.0+up5.0.0-rc2.tgz
-    version: 104.0.0+up5.0.0-rc2
+    - assets/rancher-backup-crd/rancher-backup-crd-104.0.0+up5.0.0-rc.3.tgz
+    version: 104.0.0+up5.0.0-rc.3
   - annotations:
       catalog.cattle.io/certified: rancher
       catalog.cattle.io/hidden: "true"

```