### PR TITLE
[v2.9] Add "registryconfig-auth-" secrets to backup rules

### DIFF
--- a/charts/rancher-backup/files/default-resourceset-contents/provisioningv2.yaml
+++ b/charts/rancher-backup/files/default-resourceset-contents/provisioningv2.yaml
@@ -13,7 +13,7 @@
   kindsRegexp: "."
 - apiVersion: "v1"
   kindsRegexp: "^secrets$"
-  resourceNameRegexp: "machine-plan$|rke-state$|machine-state$|machine-driver-secret$|machine-provision$|^harvesterconfig"
+  resourceNameRegexp: "machine-plan$|rke-state$|machine-state$|machine-driver-secret$|machine-provision$|^harvesterconfig|^registryconfig-auth"
   namespaces:
   - "fleet-default"
 - apiVersion: "v1"


### PR DESCRIPTION
This PR helps address the issue here: https://github.com/rancher/rancher/issues/44033

The fix being done here versus where the original issue planned means we can deliver a partial fix rather easily here. And a more complete fix that could take more time can still be done later.

This fix relies on a different BRO resourceset rule than they planned on using. And our fix will only catch secrets made via Rancher with the default generated name prefix `registryconfig-auth-` but not any secrets that the user creates outside of the "Cluster Creation UI" that may have different names.

As this is a chart change it needs to be:

- Merged here,
- Tagged in a release here, and
- New `rancher/charts` release to match.

It should also be back ported to 2.8 at the very least. Unlikely worth the effort to do that for 2.7 too.