### PR TITLE
Add GHA comment commands for porting

### DIFF
--- a/.github/workflows/port-issue.yaml
+++ b/.github/workflows/port-issue.yaml
@@ -1,0 +1,103 @@
+# create a backport/forwardport of an issue when "/backport <milestone>" is commented
+name: Port issue
+run-name: "Port issue ${{ github.event.issue.number }}: ${{ github.event.issue.title }}"
+
+on:
+  issue_comment:
+    types:
+      - created
+
+jobs:
+  port-issue:
+    runs-on: ubuntu-latest
+    if: contains(github.event.comment.body, '/backport') || contains(github.event.comment.body, '/forwardport') && !github.event.issue.pull_request
+    steps:
+      - name: Check org membership
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh api orgs/${GITHUB_REPOSITORY_OWNER}/members --paginate | jq -e --arg GITHUB_ACTOR "$GITHUB_ACTOR" '.[] | select(.login == $GITHUB_ACTOR)' > /dev/null; then
+              echo "${GITHUB_ACTOR} is a member"
+              echo "is_member=true" >> $GITHUB_ENV
+          else
+              echo "${GITHUB_ACTOR} is not a member of ${GITHUB_REPOSITORY_OWNER}" >> $GITHUB_STEP_SUMMARY
+              echo "is_member=false" >> $GITHUB_ENV
+          fi
+      - name: Check milestone
+        if: env.is_member == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ORIGINAL_ISSUE_NUMBER: ${{ github.event.issue.number }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
+        run: |
+          BODY_MILESTONE=$(echo "${COMMENT_BODY}" | awk '{ print $2 }')
+          echo "BODY_MILESTONE '${BODY_MILESTONE}'"
+
+          # Sanitize input
+          MILESTONE=${BODY_MILESTONE//[^a-zA-Z0-9\-\.]/}
+          echo "MILESTONE '${MILESTONE}'"
+
+          if gh api repos/${GITHUB_REPOSITORY}/milestones --paginate | jq -e --arg MILESTONE "$MILESTONE" '.[] | select(.title == $MILESTONE)' > /dev/null; then
+            echo "Milestone '${MILESTONE}' exists"
+            echo "milestone_exists=true" >> $GITHUB_ENV
+          else
+            echo "Milestone '${MILESTONE}' does not exist" >> $GITHUB_STEP_SUMMARY
+            gh issue comment -R ${GITHUB_REPOSITORY} ${ORIGINAL_ISSUE_NUMBER} --body "Not creating port issue, milestone ${MILESTONE} does not exist or is not an open milestone"
+            echo "milestone_exists=false" >> $GITHUB_ENV
+          fi
+      - name: Port issue
+        if: |
+          env.is_member == 'true' &&
+          env.milestone_exists == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ORIGINAL_ISSUE_NUMBER: ${{ github.event.issue.number }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
+        run: |
+          declare -a additional_cmd
+          BODY=$(mktemp)
+          ORIGINAL_ISSUE=$(gh issue view -R ${GITHUB_REPOSITORY} ${ORIGINAL_ISSUE_NUMBER} --json title,body,assignees)
+          ORIGINAL_TITLE=$(echo "${ORIGINAL_ISSUE}" | jq -r .title)
+          TYPE=$(echo "${COMMENT_BODY}" | awk '{ print $1 }' | sed -e 's_/__')
+          MILESTONE=$(echo "${COMMENT_BODY}" | awk '{ print $2 }')
+          NEW_TITLE="[${TYPE}] ${ORIGINAL_TITLE}"
+          if [[ $MILESTONE =~ (v[0-9]\.[0-9]+) ]]; then
+              NEW_TITLE="[${TYPE} ${MILESTONE}] ${ORIGINAL_TITLE}"
+          fi
+          additional_cmd+=("--label")
+          additional_cmd+=("QA/None")
+          ORIGINAL_LABELS=$(gh issue view -R ${GITHUB_REPOSITORY} ${ORIGINAL_ISSUE_NUMBER} --json labels --jq '.labels[].name' | grep -v '^\[zube\]:' | paste -sd "," -)
+          if [ -n "$ORIGINAL_LABELS" ]; then
+              additional_cmd+=("--label")
+              additional_cmd+=("${ORIGINAL_LABELS}")
+          fi
+          ORIGINAL_PROJECT=$(gh issue view -R ${GITHUB_REPOSITORY} ${ORIGINAL_ISSUE_NUMBER} --json projectItems --jq '.projectItems[].title')
+          if [ -n "$ORIGINAL_PROJECT" ]; then
+              additional_cmd+=("--project")
+              additional_cmd+=("${ORIGINAL_PROJECT}")
+          fi
+          ASSIGNEES=$(echo "${ORIGINAL_ISSUE}" | jq -r .assignees[].login)
+          if [ -n "$ASSIGNEES" ]; then
+              echo "Checking if assignee is member before assigning"
+              DELIMITER=""
+              NEW_ASSIGNEES=""
+              for ASSIGNEE in $ASSIGNEES; do
+                  if gh api orgs/${GITHUB_REPOSITORY_OWNER}/members --paginate | jq -e --arg GITHUB_ACTOR "$GITHUB_ACTOR" '.[] | select(.login == $GITHUB_ACTOR)' > /dev/null; then
+                      echo "${ASSIGNEE} is a member, adding to assignees"
+                      NEW_ASSIGNEES="${NEW_ASSIGNEES}${DELIMITER}${ASSIGNEE}"
+                      DELIMITER=","
+                  fi
+              done
+              if [ -n "$NEW_ASSIGNEES" ]; then
+                  echo "Assignees for new issue: ${NEW_ASSIGNEES}"
+                  additional_cmd+=("--assignee")
+                  additional_cmd+=("${NEW_ASSIGNEES}")
+              fi
+          fi
+          if [ -n "$MILESTONE" ]; then
+              echo -e "This is a ${TYPE} issue for #${ORIGINAL_ISSUE_NUMBER}, automatically created via [GitHub Actions workflow]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID) initiated by @${GITHUB_ACTOR}\n" > $BODY
+              echo -e "\nOriginal issue body:\n" >> $BODY
+              echo "${ORIGINAL_ISSUE}" | jq -r '.body[0:65536]' >> $BODY
+              NEW_ISSUE=$(gh issue create -R "${GITHUB_REPOSITORY}" --title "${NEW_TITLE}" --body-file "${BODY}" -m "${MILESTONE}" "${additional_cmd[@]}")
+              echo "Port issue created: ${NEW_ISSUE}" >> $GITHUB_STEP_SUMMARY
+          fi

--- a/.github/workflows/port-pr.yaml
+++ b/.github/workflows/port-pr.yaml
@@ -79,8 +79,8 @@ jobs:
           gh pr diff $ORIGINAL_ISSUE_NUMBER --patch > $PATCH_FILE
           BRANCH="gha-portpr-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           echo "branch=${BRANCH}" >> $GITHUB_ENV
-          git config --global user.email "rancherdashboardportbot@suse.com"
-          git config --global user.name "Rancher Dashboard Port Bot"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "Rancher PR Port Bot"
           git checkout -b $BRANCH
 
           if ! git am -3 "$PATCH_FILE" > error.log 2>&1; then

--- a/.github/workflows/port-pr.yaml
+++ b/.github/workflows/port-pr.yaml
@@ -1,0 +1,119 @@
+# create a backport/forwardport of a PR when "/backport <milestone>" is commented
+name: Port PR
+run-name: "Port PR ${{ github.event.issue.number }}: ${{ github.event.issue.title }}"
+
+on:
+  issue_comment:
+    types:
+      - created
+
+jobs:
+  port-pr:
+    runs-on: ubuntu-latest
+    if: (startsWith(github.event.comment.body, '/backport') || startsWith(github.event.comment.body, '/forwardport')) && github.event.issue.pull_request
+    steps:
+      - name: Check org membership
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh api orgs/${GITHUB_REPOSITORY_OWNER}/members --paginate | jq -e --arg GITHUB_ACTOR "$GITHUB_ACTOR" '.[] | select(.login == $GITHUB_ACTOR)' > /dev/null; then
+              echo "${GITHUB_ACTOR} is a member"
+              echo "is_member=true" >> $GITHUB_ENV
+          else
+              echo "${GITHUB_ACTOR} is not a member" >> $GITHUB_STEP_SUMMARY
+              echo "is_member=false" >> $GITHUB_ENV
+          fi
+      - name: Check milestone
+        if: ${{ env.is_member == 'true' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ORIGINAL_ISSUE_NUMBER: ${{ github.event.issue.number }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
+        run: |
+          BODY_MILESTONE=$(echo "${COMMENT_BODY}" | awk '{ print $2 }')
+          # Sanitize input
+          MILESTONE=${BODY_MILESTONE//[^a-zA-Z0-9\-\.]/}
+          if gh api repos/${GITHUB_REPOSITORY}/milestones --paginate | jq -e --arg MILESTONE "$MILESTONE" '.[] | select(.title == $MILESTONE)' > /dev/null; then
+              echo "Milestone exists"
+              echo "milestone_exists=true" >> $GITHUB_ENV
+              echo "milestone=${MILESTONE}" >> $GITHUB_ENV
+           else
+              echo "Milestone ${MILESTONE} does not exist" >> $GITHUB_STEP_SUMMARY
+              gh issue comment -R ${GITHUB_REPOSITORY} ${ORIGINAL_ISSUE_NUMBER} --body "Not creating port issue, milestone ${MILESTONE} does not exist or is not an open milestone"
+              echo "milestone_exists=false" >> $GITHUB_ENV
+           fi
+      - name: Get target branch
+        if: ${{ env.is_member == 'true' }} && ${{ env.milestone_exists == 'true' }}
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TYPE=$(echo "${COMMENT_BODY}" | awk '{ print $1 }' | sed -e 's_/__')
+          echo "Type: ${TYPE}" >> $GITHUB_STEP_SUMMARY
+          echo "type=${TYPE}" >> $GITHUB_ENV
+          TARGET_BRANCH=$(echo "${COMMENT_BODY}" | awk '{ print $3 }')
+          echo "Target brach: ${TARGET_BRANCH}" >> $GITHUB_STEP_SUMMARY
+          echo "target_branch=${TARGET_BRANCH}" >> $GITHUB_ENV
+          if gh api repos/${GITHUB_REPOSITORY}/branches --paginate | jq -e --arg TARGET_BRANCH "$TARGET_BRANCH" '.[] | select(.name == $TARGET_BRANCH)' > /dev/null; then
+              echo "target_branch_exists=true" >> $GITHUB_ENV
+          else
+              echo "target_branch_exists=false" >> $GITHUB_ENV
+          fi
+      - name: Checkout
+        if: ${{ env.is_member == 'true' }} && ${{ env.milestone_exists == 'true' }} && ${{ env.target_branch_exists == 'true' }}
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.target_branch }}
+          fetch-depth: '0'
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Port PR
+        if: ${{ env.is_member == 'true' }} && ${{ env.milestone_exists == 'true' }} && ${{ env.target_branch_exists == 'true' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ORIGINAL_ISSUE_NUMBER: ${{ github.event.issue.number }}
+          TYPE: ${{ env.type }}
+          TARGET_BRANCH: ${{ env.target_branch }}
+          MILESTONE: ${{ env.milestone }}
+        run: |
+          PATCH_FILE=$(mktemp)
+          gh pr diff $ORIGINAL_ISSUE_NUMBER --patch > $PATCH_FILE
+          BRANCH="gha-portpr-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          echo "branch=${BRANCH}" >> $GITHUB_ENV
+          git config --global user.email "rancherdashboardportbot@suse.com"
+          git config --global user.name "Rancher Dashboard Port Bot"
+          git checkout -b $BRANCH
+
+          if ! git am -3 "$PATCH_FILE" > error.log 2>&1; then
+              ERROR_MESSAGE=$(cat error.log)
+              FORMATTED_ERROR_MESSAGE=$(printf "\n\`\`\`\n%s\n\`\`\`" "$ERROR_MESSAGE")
+              gh issue comment ${ORIGINAL_ISSUE_NUMBER} --body "Not creating port PR, there was an error running git am -3: $FORMATTED_ERROR_MESSAGE"
+          else
+              git push origin $BRANCH
+              ORIGINAL_PR=$(gh pr view ${ORIGINAL_ISSUE_NUMBER} --json title,body,assignees)
+              ORIGINAL_TITLE=$(echo "${ORIGINAL_PR}" | jq -r .title)
+              ORIGINAL_ASSIGNEE=$(echo "${ORIGINAL_PR}" | jq -r '.assignee.login // empty')
+              BODY=$(mktemp)
+              echo -e "This is an automated request to port PR #${ORIGINAL_ISSUE_NUMBER} by @${GITHUB_ACTOR}\n\n" > $BODY
+              echo -e "Original PR body:\n\n" >> $BODY
+              echo "${ORIGINAL_PR}" | jq -r .body >> $BODY
+              ASSIGNEES=$(echo "${ORIGINAL_PR}" | jq -r .assignees[].login)
+              if [ -n "$ASSIGNEES" ]; then
+                  echo "Checking if assignee is member before assigning"
+                  DELIMITER=""
+                  NEW_ASSIGNEES=""
+                  for ASSIGNEE in $ASSIGNEES; do
+                      if gh api orgs/${GITHUB_REPOSITORY_OWNER}/members --paginate | jq -e --arg GITHUB_ACTOR "$GITHUB_ACTOR" '.[] | select(.login == $GITHUB_ACTOR)' > /dev/null; then
+                          echo "${ASSIGNEE} is a member, adding to assignees"
+                          NEW_ASSIGNEES="${NEW_ASSIGNEES}${DELIMITER}${ASSIGNEE}"
+                          DELIMITER=","
+                      fi
+                  done
+                  if [ -n "$NEW_ASSIGNEES" ]; then
+                      echo "Assignees for new issue: ${NEW_ASSIGNEES}"
+                      additional_cmd+=("--assignee")
+                      additional_cmd+=("${NEW_ASSIGNEES}")
+                  fi
+              fi
+              NEW_PR=$(gh pr create --title="[${TYPE} ${MILESTONE}] ${ORIGINAL_TITLE}" --body-file="${BODY}" --head "${BRANCH}" --base "${TARGET_BRANCH}" --milestone "${MILESTONE}" "${additional_cmd[@]}")
+              echo "Port PR created: ${NEW_PR}" >> $GITHUB_STEP_SUMMARY
+          fi


### PR DESCRIPTION
These GHA commands allow us to create comments like:

- `/backport release/4.0`
- `/forwardport release/5.0`
- `/backport v2.8.next1`

Where when it's on a PR you should provide a specific branch on this repo and it will create a new PR based on it targeting the new branch. And when it's an Issue it will create a new issue to track porting it to the tagged rancher release name.