### PR TITLE
Adjust renovate groups & enable cron

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,7 @@
 {
   "extends": [
     "github>rancher/renovate-config#release",
-    "group:all"
+    "group:allNonMajor"
   ],
   "baseBranches": [
     "release/v3.0",
@@ -14,5 +14,21 @@
     "github.com/rancher/wrangler",
     "github.com/rancher/wrangler/v2",
     "github.com/rancher/wrangler/v3"
+  ],
+  "packageRules": [
+    {
+      "groupName": "GitHub Workflow Actions",
+      "groupSlug": "gha-deps",
+      "matchManagers": [
+        "github-actions"
+      ]
+    },
+    {
+      "groupName": "Docker File Deps",
+      "groupSlug": "docker-bumps",
+      "matchManagers": [
+        "dockerfile"
+      ]
+    }
   ]
 }

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -13,8 +13,8 @@ on:
         default: "false"
         type: string
   # Run twice in the early morning (UTC) for initial and follow up steps (create pull request and merge)
-  # schedule:
-  #   - cron: '30 4,6 * * *'
+  schedule:
+    - cron: '30 4,6 * * *'
 
 jobs:
   call-workflow:


### PR DESCRIPTION
The current settings create really large PRs that mix all types of version bumps (major, minor, etc). And all the contexts (GH actions, docker files, go deps) into the same PR too.

With this change we will technically get more PRs but they will come thru grouped by what feel like safer groups. Since for example in this PR: https://github.com/rancher/backup-restore-operator/pull/493

I wouldn't feel as confident merging the `mergo` change from v0.3.16 -> v1.0.0. But do feel confident merging the GHA workflow changing from v5 -> v6. So this highlights where 2 major bumps are not equal (cause for concern).

This will allow us to more easily and simply just bump the GHA workflows as we need. Lettings us merge those CI bumps whenever we want. And then any actual bumps that directly go into the code we ship can be scrutinized without delaying those bumps.