### PR TITLE
update codeowner to O&B instead of individual users

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,1 @@
-# These owners will be the default owners for everything in
-# the repo. Unless a later match takes precedence,
-# @eliyamlevy and @superseb will be requested for
-# review when someone opens a pull request.
-*       @eliyamlevy
-*       @ericpromislow
+*       @rancher/observation-backup


### PR DESCRIPTION
This should adjust how the default reviewer works - so that it will assign it to our whole team instead of Eric everytime.