### PR TITLE
Add rule for UIPlugin resources in default ResourceSet

### DIFF
--- a/charts/rancher-backup/files/default-resourceset-contents/rancher.yaml
+++ b/charts/rancher-backup/files/default-resourceset-contents/rancher.yaml
@@ -63,3 +63,7 @@
       - key: "resources.cattle.io/backup"
         operator: "In"
         values: ["true"]
+- apiVersion: catalog.cattle.io/v1
+  kindsRegexp: ^UIPlugin$
+  namespaces:
+  - cattle-ui-plugin-system


### PR DESCRIPTION
This PR seeks to resolve issue [#483](https://github.com/rancher/backup-restore-operator/issues/483)

## Test Steps
- In a local cluster with the Kamaji UI extension installed, manually edited the default ResourceSet to include the new rule for UIPlugins.
- Took a backup (B1)
- See if B1 correctly includes the Kamaji UIPlugin
- Create a new cluster and restore the backup as detailed [here](https://ranchermanager.docs.rancher.com/v2.6/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster)
- Once restored, enable extensions in the new cluster and reload the page. Check if Kamaji UI remains correctly installed.