### PR TITLE
Add docs about creating a patch release branch

### DIFF
--- a/docs/creating-a-patch-release-branch.md
+++ b/docs/creating-a-patch-release-branch.md
@@ -27,7 +27,7 @@ How do we make those moves?
 Once the new branch is pushed to Rancher remote repo you should PR a backport to it.
 
 In general treat this the same way as a normal release branch for older release versions.
-Meaning we should only backport to these branches and never forward-port to from them to others.
+Meaning we should only backport to these branches and never forward-port from them to others.
 
 ### How do I release from a patch release branch?
 

--- a/docs/creating-a-patch-release-branch.md
+++ b/docs/creating-a-patch-release-branch.md
@@ -40,7 +40,7 @@ How do we make those moves?
 
 > Note: You will need to update the above examples for your situation.
 > Pay close attention to what tag you checkout, the version of the patch branch, and the name of the remote you push to.
-> In this example "upstream" is the `rancher/backup-restore-repo`.
+> In this example "upstream" is the `rancher/backup-restore-operator` repo.
 
 Once the new branch is pushed to Rancher remote repo you should PR a backport to it.
 
@@ -49,6 +49,6 @@ Meaning we should only backport to these branches and never forward-port from th
 
 ### How do I release from a patch release branch?
 
-Follow the normal process however, the only version that we will ever release from the branch is the one it mathches.
+Follow the normal process however, the only version that we will ever release from the branch is the one it matches.
 In the example above, we should only produce `v5.0.1` based releases (alphas, betas, RCs, and stable).
 The patch release branch should not be used to produce any other release versions.

--- a/docs/creating-a-patch-release-branch.md
+++ b/docs/creating-a-patch-release-branch.md
@@ -36,7 +36,11 @@ How do we make those moves?
 
 1. Start by checking out the tag being patched: ```git checkout tags/v5.0.0```
 2. Now create a new patch branch from this spot: ```git checkout -b release/v5.0.1```
-3. Push the new patch branch to the BRO repo.
+3. Push the new patch branch to the BRO repo: ```git push upstream release/v5.0.1```
+
+> Note: You will need to update the above examples for your situation.
+> Pay close attention to what tag you checkout, the version of the patch branch, and the name of the remote you push to.
+> In this example "upstream" is the `rancher/backup-restore-repo`.
 
 Once the new branch is pushed to Rancher remote repo you should PR a backport to it.
 

--- a/docs/creating-a-patch-release-branch.md
+++ b/docs/creating-a-patch-release-branch.md
@@ -31,6 +31,6 @@ Meaning we should only backport to these branches and never forward-port to from
 
 ### How do I release from a patch release branch?
 
-Follow the normal process however, the only version that we will ever release from the branch is the one it mathces.
+Follow the normal process however, the only version that we will ever release from the branch is the one it mathches.
 In the example above, we should only produce `v5.0.1` based releases (alphas, betas, RCs, and stable).
 The patch release branch should not be used to produce any other release versions.

--- a/docs/creating-a-patch-release-branch.md
+++ b/docs/creating-a-patch-release-branch.md
@@ -4,16 +4,30 @@ This doc will cover the how's and when's of creating a minor release branch for 
 Ideally for this repo we will not create these before we need them to reduce branch noise.
 So in this repo "patch release branch" should only be created JIT, not preemptively.
 
+### What is a patch release branch?
+A patch release branch is simply a branch targeting a specific patch version.
+
+An example of this would be the [`release/v2.8.5`](https://github.com/rancher/rancher/tree/release/v2.8.5) branch on the `rancher/rancher` repo.
+As this branch exists so that the team could produce a `v2.8.5` that only fixes upon `v2.8.4`.
+Rather than include all the changes included in `release/v2.8` at the time which may target a later release.
+
 ### Why would I create a patch release branch?
-Technically repos like ours do not have to withhold progress due to the main rancher/rancher code-freeze.
-So in theory we can continue merging to our release branch as we please during a release freeze.
+During the release process of `rancher/rancher` there are phases when we cannot merge PRs to that repo.
+And often other repositories honor that freeze as well to simplify things if a patch were needed.
 
-Unfortunately, if PRs are merged and need to create a last minute patch release the HEAD branch is no longer valid for this.
-As cutting a release from that would include more changes than the small fix a last minute patch would require.
+Yet, observing that code freeze can reduce forward progress for repos like this one.
+The primary benefit to observing the freeze is it avoids needing and using a process like this.
+However, if a process is established then a squad/repo should be able to continue forward progress.
 
-In that event, you would need to create a `release/vX.Y.(Z+1)` branch where all values are defined based on the version being patched.
-This new patch release branch would be created based on the original tag being patched.
-Finally, you will backport the fix from the HEAD release branch to this patch release branch.
+### When would I create a patch release branch?
+
+Essentially, if PRs are merged during a time when `r/r` is frozen and we need to create a last minute patch release.
+In this situation, the HEAD branch is no longer valid for this as cutting a release would include more changes.
+And we should only ship a small fix in this patch release required to fix the issue.
+
+In that event, you would create a `release/vX.Y.(Z+1)` branch based on the version needing a patch.
+First you would implement the patch on the `release/vX.Y` branch and verify it fixes the issue.
+Finally, you will backport that fix from the HEAD release branch to this new patch release branch.
 
 ### How do I create a patch release branch?
 

--- a/docs/creating-a-patch-release-branch.md
+++ b/docs/creating-a-patch-release-branch.md
@@ -1,0 +1,36 @@
+## Creating a patch release branch
+
+This doc will cover the how's and when's of creating a minor release branch for BRO. 
+Ideally for this repo we will not create these before we need them to reduce branch noise.
+So in this repo "patch release branch" should only be created JIT, not preemptively.
+
+### Why would I create a patch release branch?
+Technically repos like ours do not have to withhold progress due to the main rancher/rancher code-freeze.
+So in theory we can continue merging to our release branch as we please during a release freeze.
+
+Unfortunately, if PRs are merged and need to create a last minute patch release the HEAD branch is no longer valid for this.
+As cutting a release from that would include more changes than the small fix a last minute patch would require.
+
+In that event, you would need to create a `release/vX.Y.(Z+1)` branch where all values are defined based on the version being patched.
+This new patch release branch would be created based on the original tag being patched.
+Finally, you will backport the fix from the HEAD release branch to this patch release branch.
+
+### How do I create a patch release branch?
+
+Best demonstrated by example, lets assume we need to patch BRO `v5.0.0` and don't want any new changes in `release/v5.0`.
+How do we make those moves?
+
+1. Start by checking out the tag being patched: ```git checkout tags/v5.0.0```
+2. Now create a new patch branch from this spot: ```git checkout -b release/v5.0.1```
+3. Push the new patch branch to the BRO repo.
+
+Once the new branch is pushed to Rancher remote repo you should PR a backport to it.
+
+In general treat this the same way as a normal release branch for older release versions.
+Meaning we should only backport to these branches and never forward-port to from them to others.
+
+### How do I release from a patch release branch?
+
+Follow the normal process however, the only version that we will ever release from the branch is the one it mathces.
+In the example above, we should only produce `v5.0.1` based releases (alphas, betas, RCs, and stable).
+The patch release branch should not be used to produce any other release versions.


### PR DESCRIPTION
The goal of adding this doc is so that this repo can have a documented process for this.
In theory with that process laid out for everyone to follow we can continue merging PRs to HEAD branches during r/r freeze with more confidence. And this could potentially allow us more time/flexibility to address the renovate PRs.

# Warning

Before we execute on this practice across all our maintained branches we will first need to:

1. Edit GHA workflows to allow tests/ci to run based on any `release/*` (or similar) branch regex,
2. Sync all workflows to older branches via backport.

Eventually we can still adjust how we manage workflows in this repo if that's desired. Since we've been discussing some methods of keeping the workflows in sync across all branches more easily. (Automatic backports, orphan branch of canonical workflows, dedicated workflow repo etc)