### PR TITLE
[CI] Allow ci workflow to run on patch release branches

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,7 @@ on:
       - release/v5.0
       - release/v4.0
       - release/v3.0
+      - release/v*.*.*
     paths-ignore:
       - 'docs/**'
       - '*.md'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ on:
       - release/v5.0
       - release/v4.0
       - release/v3.0
-      - release/v*.*.*
+      - release/v[0-9]+.[0-9]+.[0-9]+
     paths-ignore:
       - 'docs/**'
       - '*.md'


### PR DESCRIPTION
As an extension of https://github.com/rancher/backup-restore-operator/pull/512 this PR tweaks the CI workflow to allow it to run on our current release branches and future patch release branches.

We could also expand this to run on `release/v*.*` and not care about back-porting to anything before `release/v3` since those should never run if they never get PRs (the goal). If not then we'll just cycle in and out release minor branches as appropriate - but I could see a benefit to just start using wild cards there now.