### PR TITLE
Add a version to goreleaser config

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,4 +1,5 @@
 # Make sure to check the documentation at https://goreleaser.com
+version: 2 # the goreleaser config version
 before:
   hooks:
     - go mod tidy


### PR DESCRIPTION
This will silence a warning in CI:
>   • only configurations files on version: 2 are supported, yours is version: 0, please update your configuration
