### PR TITLE
[backport] Update issue label v3.0

### DIFF
--- a/.github/workflows/label-all-new-issues.yml
+++ b/.github/workflows/label-all-new-issues.yml
@@ -17,4 +17,4 @@ jobs:
         run: gh issue edit -R ${GITHUB_REPOSITORY} --add-label ${LABEL} ${{ github.event.issue.number }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          LABEL: "team/area3"
+          LABEL: "team/observability&backup"


### PR DESCRIPTION
Auto issue label is set to the old team name. This PR seeks to update it.

Fixes [#523](https://github.com/rancher/backup-restore-operator/issues/523)