### PR TITLE
Adding fleet-agent exclusion for backup restore

### DIFF
--- a/charts/rancher-backup/files/default-resourceset-contents/fleet.yaml
+++ b/charts/rancher-backup/files/default-resourceset-contents/fleet.yaml
@@ -20,6 +20,7 @@
 - apiVersion: "v1"
   kindsRegexp: "^configmaps$"
   namespaceRegexp: "^cattle-fleet-|^fleet-"
+  excludeResourceNameRegexp: "fleet-agent*"
 - apiVersion: "rbac.authorization.k8s.io/v1"
   kindsRegexp: "^roles$|^rolebindings$"
   namespaceRegexp: "^cattle-fleet-|^fleet-"


### PR DESCRIPTION
Attempting to implement exclusion for `fleet-agent` during  during backup restore (https://github.com/rancher/fleet/issues/2683) .