### PR TITLE
Add mergo into Renovate dependency ignore-list

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -13,7 +13,8 @@
     "github.com/rancher/lasso",
     "github.com/rancher/wrangler",
     "github.com/rancher/wrangler/v2",
-    "github.com/rancher/wrangler/v3"
+    "github.com/rancher/wrangler/v3",
+    "github.com/imdario/mergo"
   ],
   "packageRules": [
     {


### PR DESCRIPTION
Updating the _mergo_ dependency can cause breaking changes.

Example PR: [#541](https://github.com/rancher/backup-restore-operator/pull/541)