### PR TITLE
[main] Fully Implement Head Tagging

### DIFF
--- a/.github/scripts/branch-tags.sh
+++ b/.github/scripts/branch-tags.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# Exit immediately if a command exits with a non-zero status
+set -e
+
+# Function to get the previous tag
+getPreviousTag() {
+  local tagPrefix="$1"
+  # List all tags and filter ones that start with tagPrefix, sort by creation date
+  git tag --sort=-creatordate | grep "^${tagPrefix}" | head -n 1
+}
+
+# Determine if we're in a GitHub Actions environment
+if [ -n "$GITHUB_REF" ] && [ -n "$GITHUB_SHA" ]; then
+  # Use GHA environment variables
+  ref="$GITHUB_REF"
+  commitSha="${GITHUB_SHA:0:7}"
+else
+  # Fallback to local Git repo
+  if [ ! -d ".git" ]; then
+    echo "This script must be run from the root of a Git repository or GitHub Actions."
+    exit 1
+  fi
+  ref=$(git symbolic-ref HEAD)
+  commitSha=$(git rev-parse --short HEAD)
+fi
+
+branchTag=""
+branchStaticTag=""
+prevTag=""
+
+if [ "$ref" == "refs/heads/main" ]; then
+  branchTag="head"
+  branchStaticTag="main-${commitSha}"
+  prevTag=$(getPreviousTag "main-")
+elif [[ "$ref" == refs/heads/release/* ]]; then
+  version="${ref#refs/heads/release/}"  # Extract "vX.0"
+  branchTag="${version}-head"
+  branchStaticTag="${version}-head-${commitSha}"
+  prevTag=$(getPreviousTag "${version}-head-")
+else
+  echo "Unsupported branch pattern. Expected 'main' or 'release/*'."
+  exit 1
+fi
+
+# Output the results
+echo "branch_tag=${branchTag}"
+echo "branch_static_tag=${branchStaticTag}"
+echo "prev_static_tag=${prevTag}"

--- a/.github/workflows/head-releases.yaml
+++ b/.github/workflows/head-releases.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - gha-testtesttest
       - release/v[0-9]+.0
 
 concurrency:

--- a/.github/workflows/head-releases.yaml
+++ b/.github/workflows/head-releases.yaml
@@ -1,0 +1,82 @@
+name : Branch Head Prerelease Images & artifacts (via goreleaser)
+
+on:
+  push:
+    branches:
+      - main
+      - gha-testtesttest
+      - release/v[0-9]+.0
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  REGISTRY: docker.io
+  REPO : rancher
+
+permissions:
+  contents: write
+
+jobs:
+  prebuild-env:
+    name: Prebuild needed Env vars
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository to the runner
+        uses: actions/checkout@v4
+      - name: Set Branch Tag and Other Variables
+        id: set-vars
+        run: bash ./.github/scripts/branch-tags.sh >> $GITHUB_OUTPUT
+    outputs:
+      branch_tag: ${{ steps.set-vars.outputs.branch_tag }}
+      branch_static_tag: ${{ steps.set-vars.outputs.branch_static_tag }}
+      prev_tag: ${{ steps.set-vars.outputs.prev_tag }}
+  push:
+    needs : [
+      prebuild-env,
+    ]
+    permissions:
+      contents : read
+      id-token: write
+    name : Build and push BRO images
+    runs-on : ubuntu-latest
+    steps:
+      - name : "Read vault secrets"
+        uses : rancher-eio/read-vault-secrets@main
+        if: ${{ github.repository_owner == 'rancher' }}
+        with:
+          secrets: |
+            secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials username | DOCKER_USERNAME ;
+            secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials password | DOCKER_PASSWORD
+      - name : Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3 
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ env.DOCKER_USERNAME || vars.REPO }}
+          password: ${{ env.DOCKER_PASSWORD || secrets.DOCKER_PW }}
+      - name: Build and push BRO image
+        env:
+          FULL_IMAGE_URL: "${{ env.REGISTRY }}/${{ vars.REPO || env.REPO || github.repository_owner }}/backup-restore-operator"
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./package/Dockerfile
+          build-args: |
+            TAG=${{ needs.prebuild-env.outputs.branch_static_tag }}
+          push: true
+          tags: ${{ env.FULL_IMAGE_URL }}:${{ needs.prebuild-env.outputs.branch_static_tag }}
+          platforms: linux/amd64,linux/arm64
+      - name: Update rolling tag to new static tag
+        env:
+          FULL_IMAGE_URL: ${{ env.REGISTRY }}/${{ vars.REPO || env.REPO || github.repository_owner }}/backup-restore-operator
+        run: |
+          VERSION="1.2.0"
+          curl -LO "https://github.com/oras-project/oras/releases/download/v${VERSION}/oras_${VERSION}_linux_amd64.tar.gz"
+          mkdir -p oras-install/
+          tar -zxf oras_${VERSION}_*.tar.gz -C oras-install/
+          oras-install/oras copy ${{ env.FULL_IMAGE_URL }}:${{ needs.prebuild-env.outputs.branch_static_tag }} ${{ env.FULL_IMAGE_URL }}:${{ needs.prebuild-env.outputs.branch_tag }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -2,8 +2,6 @@ name : Publish Images & artifacts (via goreleaser)
 
 on:
   push:
-    branches:
-      - main
     tags:
       - "*"
 
@@ -75,5 +73,5 @@ jobs:
           context: .
           file: ./package/Dockerfile
           push: true
-          tags: ${{ env.REGISTRY }}/${{ env.REPO }}/backup-restore-operator:${{ github.ref == 'refs/heads/main' && 'head' || github.ref_name }}
+          tags: ${{ env.REGISTRY }}/${{ env.REPO }}/backup-restore-operator:${{ github.ref_name }}
           platforms: linux/amd64,linux/arm64

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,4 +1,9 @@
 FROM registry.suse.com/bci/golang:1.22 AS builder
+
+ARG TAG=''
+ARG REPO=''
+ENV TAG=$TAG REPO=$REPO
+
 WORKDIR /usr/src/app
 COPY go.mod go.sum ./
 RUN go mod download

--- a/scripts/version
+++ b/scripts/version
@@ -6,7 +6,7 @@ if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
 fi
 
 COMMIT=$(git rev-parse --short HEAD)
-GIT_TAG=${DRONE_TAG:-$(git tag -l --contains HEAD | head -n 1)}
+GIT_TAG=$(git tag -l --contains HEAD | head -n 1)
 
 if [[ -z "$DIRTY" && -n "$GIT_TAG" ]]; then
     VERSION=$GIT_TAG


### PR DESCRIPTION
This PR adds scripts necessary for properly tagging the Image artifacts produced from "head builds". This way we can have an effective method to have a "rolling head tag" for each major branch without loosing access to past "head images".

This will close out https://github.com/rancher/backup-restore-operator/issues/565 with the only final goal being t he docker images as an artifact of head builds. As full releases with Charts and bins wouldn't really make sense since these are intended to improve Dev/QA workflows and not intended for other consumption.

---

For review of the action changes, please see: https://github.com/mallardduck/backup-restore-operator/actions/runs/10621704184

As that was a test run (of these same effective changes) before I prepared this branch for PR.

