### PR TITLE
Backup `machine-plan` secrets independent of namespace (close  Restore renders downstream cluster unusable if this one resides in a non-`fleet-default` namespace #574)

### DIFF
--- a/charts/rancher-backup/files/default-resourceset-contents/provisioningv2.yaml
+++ b/charts/rancher-backup/files/default-resourceset-contents/provisioningv2.yaml
@@ -14,8 +14,7 @@
 - apiVersion: "v1"
   kindsRegexp: "^secrets$"
   resourceNameRegexp: "machine-plan$|rke-state$|machine-state$|machine-driver-secret$|machine-provision$|^harvesterconfig|^registryconfig-auth"
-  namespaces:
-  - "fleet-default"
+  namespaceRegexp: "^.*$"
 - apiVersion: "v1"
   kindsRegexp: "^configmaps$"
   resourceNames:


### PR DESCRIPTION
close #574