### PR TITLE
Add FleetWorkspaces and their namespace to backup config

### DIFF
--- a/charts/rancher-backup/files/default-resourceset-contents/fleet.yaml
+++ b/charts/rancher-backup/files/default-resourceset-contents/fleet.yaml
@@ -1,6 +1,14 @@
+- apiVersion: "management.cattle.io/v3"
+  kindsRegexp: "^fleetworkspaces$"
 - apiVersion: "v1"
   kindsRegexp: "^namespaces$"
   resourceNameRegexp: "^fleet-"
+  # also match any namespaces created for workspaces
+  labelSelectors:
+    matchExpressions:
+      - key: "app.kubernetes.io/managed-by"
+        operator: "In"
+        values: ["rancher"]
 - apiVersion: "v1"
   kindsRegexp: "^secrets$"
   namespaceRegexp: "^cattle-fleet-|^fleet-"


### PR DESCRIPTION
Refers to https://github.com/rancher/backup-restore-operator/issues/482

* add fleetworkspaces resource to backup config
* add any namespace created by that resource, identifiable by the "app.kubernetes.io/managed-by=rancher" label, too


The "fleet-local" and "fleet-default" workspaces are special, their namespaces don't have the label, but are backed up explicitly because their resource names start with "fleet-". 