### PR TITLE
Capture namespaces managed by rancher (created by fleet)

### DIFF
--- a/charts/rancher-backup/files/default-resourceset-contents/fleet.yaml
+++ b/charts/rancher-backup/files/default-resourceset-contents/fleet.yaml
@@ -2,6 +2,13 @@
   kindsRegexp: "^namespaces$"
   resourceNameRegexp: "^fleet-"
 - apiVersion: "v1"
+  kindsRegexp: "^namespaces$"
+  labelSelectors:
+    matchExpressions:
+      - key: "app.kubernetes.io/managed-by"
+        operator: "In"
+        values: ["rancher"]
+- apiVersion: "v1"
   kindsRegexp: "^secrets$"
   namespaceRegexp: "^cattle-fleet-|^fleet-"
   excludeResourceNameRegexp: "^import-token"


### PR DESCRIPTION
Start backing up any namespace with label of `app.kubernetes.io/managed-by=rancher`
Improves: https://github.com/rancher/backup-restore-operator/issues/482