### PR TITLE
Fix Elemental metadata backup

### DIFF
--- a/charts/rancher-backup/files/default-resourceset-contents/elemental.yaml
+++ b/charts/rancher-backup/files/default-resourceset-contents/elemental.yaml
@@ -30,7 +30,7 @@
   resourceNameRegexp: "elemental.cattle.io$"
 - apiVersion: "elemental.cattle.io/v1beta1"
   kindsRegexp: "."
-  namespaceRegexp: "^cattle-fleet-|^fleet-"
+  namespaceRegexp: "^cattle-fleet-|^fleet-|^cattle-elemental-system$"
 - apiVersion: "rbac.authorization.k8s.io/v1"
   kindsRegexp: "^roles$|^rolebindings$"
   labelSelectors:


### PR DESCRIPTION
Kind `metadata` is not saved, this PR should fix it. A backport to `release/v4.0` and `release/v5.0` is also needed.