### PR TITLE
[main] Add new method to track originating cluster of Backup

### DIFF
--- a/charts/rancher-backup-crd/templates/backup.yaml
+++ b/charts/rancher-backup-crd/templates/backup.yaml
@@ -127,6 +127,9 @@ spec:
                 type: string
               observedGeneration:
                 type: integer
+              originCluster:
+                nullable: true
+                type: string
               storageLocation:
                 nullable: true
                 type: string

--- a/charts/rancher-backup-crd/templates/backup.yaml
+++ b/charts/rancher-backup-crd/templates/backup.yaml
@@ -29,6 +29,9 @@ spec:
     - jsonPath: .status.conditions[?(@.type=="Ready")].message
       name: Status
       type: string
+    - jsonPath: .status.conditions[?(@.type=="InPlaceRestore")].status
+      name: In-Place
+      type: string
     name: v1
     schema:
       openAPIV3Schema:

--- a/pkg/apis/resources.cattle.io/v1/types.go
+++ b/pkg/apis/resources.cattle.io/v1/types.go
@@ -6,14 +6,15 @@ import (
 )
 
 var (
-	BackupConditionReady         = "Ready"
-	BackupConditionUploaded      = "Uploaded"
-	BackupConditionReconciling   = "Reconciling"
-	BackupConditionClusterOrigin = "ClusterOrigin"
-	BackupConditionStalled       = "Stalled"
-	RestoreConditionReconciling  = "Reconciling"
-	RestoreConditionStalled      = "Stalled"
-	RestoreConditionReady        = "Ready"
+	BackupConditionReady          = "Ready"
+	BackupConditionUploaded       = "Uploaded"
+	BackupConditionReconciling    = "Reconciling"
+	BackupConditionClusterOrigin  = "HasClusterOrigin"
+	BackupConditionInPlaceRestore = "InPlaceRestore"
+	BackupConditionStalled        = "Stalled"
+	RestoreConditionReconciling   = "Reconciling"
+	RestoreConditionStalled       = "Stalled"
+	RestoreConditionReady         = "Ready"
 )
 
 const (

--- a/pkg/apis/resources.cattle.io/v1/types.go
+++ b/pkg/apis/resources.cattle.io/v1/types.go
@@ -6,13 +6,14 @@ import (
 )
 
 var (
-	BackupConditionReady        = "Ready"
-	BackupConditionUploaded     = "Uploaded"
-	BackupConditionReconciling  = "Reconciling"
-	BackupConditionStalled      = "Stalled"
-	RestoreConditionReconciling = "Reconciling"
-	RestoreConditionStalled     = "Stalled"
-	RestoreConditionReady       = "Ready"
+	BackupConditionReady         = "Ready"
+	BackupConditionUploaded      = "Uploaded"
+	BackupConditionReconciling   = "Reconciling"
+	BackupConditionClusterOrigin = "ClusterOrigin"
+	BackupConditionStalled       = "Stalled"
+	RestoreConditionReconciling  = "Reconciling"
+	RestoreConditionStalled      = "Stalled"
+	RestoreConditionReady        = "Ready"
 )
 
 const (

--- a/pkg/apis/resources.cattle.io/v1/types.go
+++ b/pkg/apis/resources.cattle.io/v1/types.go
@@ -15,6 +15,10 @@ var (
 	RestoreConditionReady       = "Ready"
 )
 
+const (
+	BackupClusterOriginIndex = "field.cattle.io/originClusterId"
+)
+
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/resources.cattle.io/v1/types.go
+++ b/pkg/apis/resources.cattle.io/v1/types.go
@@ -17,10 +17,6 @@ var (
 	RestoreConditionReady         = "Ready"
 )
 
-const (
-	BackupClusterOriginIndex = "field.cattle.io/originClusterId"
-)
-
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -43,6 +39,7 @@ type BackupSpec struct {
 
 type BackupStatus struct {
 	Conditions         []genericcondition.GenericCondition `json:"conditions"`
+	OriginCluster      string                              `json:"originCluster,omitempty"`
 	LastSnapshotTS     string                              `json:"lastSnapshotTs"`
 	NextSnapshotAt     string                              `json:"nextSnapshotAt"`
 	ObservedGeneration int64                               `json:"observedGeneration"`

--- a/pkg/controllers/backup/cluster_origin.go
+++ b/pkg/controllers/backup/cluster_origin.go
@@ -16,7 +16,7 @@ type backupClusterOriginConditionMeta struct {
 	currentInPlaceRestoreCondition bool
 }
 
-func newBackupClusterOriginConditionMeta(controllerClusterId string, backup *v1.Backup) backupClusterOriginConditionMeta {
+func newBackupClusterOriginConditionMeta(controllerClusterID string, backup *v1.Backup) backupClusterOriginConditionMeta {
 	conditionMeta := backupClusterOriginConditionMeta{
 		backupName:                     backup.Name,
 		hasClusterOriginID:             false,
@@ -40,7 +40,7 @@ func newBackupClusterOriginConditionMeta(controllerClusterId string, backup *v1.
 	}
 
 	if conditionMeta.hasClusterOriginID {
-		conditionMeta.canInPlaceRestore = conditionMeta.clusterOriginID == controllerClusterId
+		conditionMeta.canInPlaceRestore = conditionMeta.clusterOriginID == controllerClusterID
 	}
 
 	currentInPlaceRestoreString := condition.Cond(v1.BackupConditionInPlaceRestore).GetStatus(backup)

--- a/pkg/controllers/backup/cluster_origin.go
+++ b/pkg/controllers/backup/cluster_origin.go
@@ -72,6 +72,7 @@ func (h *handler) prepareClusterOriginConditions(backup *v1.Backup) bool {
 		return conditionChanged
 	}
 
+	// TODO: We could add a fallback mode that uses filenames (and/or the annotation) when the CRD is not updated
 	conditionMeta := newBackupClusterOriginConditionMeta(h.kubeSystemNS, backup)
 
 	// Fist pass we only care to set BackupConditionClusterOrigin based on if the context is there

--- a/pkg/controllers/backup/cluster_origin.go
+++ b/pkg/controllers/backup/cluster_origin.go
@@ -1,0 +1,91 @@
+package backup
+
+import (
+	v1 "github.com/rancher/backup-restore-operator/pkg/apis/resources.cattle.io/v1"
+	"github.com/rancher/wrangler/v3/pkg/condition"
+)
+
+type backupClusterOriginConditionMeta struct {
+	backupName                     string
+	hasClusterOriginID             bool
+	clusterOriginID                string
+	hasCurrentOriginCondition      bool
+	currentOriginCondition         bool
+	canInPlaceRestore              bool
+	hasInPlaceRestoreCondition     bool
+	currentInPlaceRestoreCondition bool
+}
+
+func newBackupClusterOriginConditionMeta(controllerClusterId string, backup *v1.Backup) backupClusterOriginConditionMeta {
+	conditionMeta := backupClusterOriginConditionMeta{
+		backupName:                     backup.Name,
+		hasClusterOriginID:             false,
+		hasCurrentOriginCondition:      false,
+		currentOriginCondition:         false,
+		canInPlaceRestore:              false,
+		hasInPlaceRestoreCondition:     false,
+		currentInPlaceRestoreCondition: false,
+	}
+
+	originAnnotationValue, ok := backup.GetAnnotations()[v1.BackupClusterOriginIndex]
+	conditionMeta.hasClusterOriginID = ok && originAnnotationValue != ""
+	if conditionMeta.hasClusterOriginID {
+		conditionMeta.clusterOriginID = originAnnotationValue
+	}
+
+	currentOriginConditionString := condition.Cond(v1.BackupConditionClusterOrigin).GetStatus(backup)
+	conditionMeta.hasCurrentOriginCondition = currentOriginConditionString != ""
+	if !conditionMeta.hasCurrentOriginCondition {
+		conditionMeta.currentOriginCondition = currentOriginConditionString == "True"
+	}
+
+	if conditionMeta.hasClusterOriginID {
+		conditionMeta.canInPlaceRestore = conditionMeta.clusterOriginID == controllerClusterId
+	}
+
+	currentInPlaceRestoreString := condition.Cond(v1.BackupConditionInPlaceRestore).GetStatus(backup)
+	conditionMeta.hasInPlaceRestoreCondition = currentInPlaceRestoreString != ""
+	if !conditionMeta.hasInPlaceRestoreCondition {
+		conditionMeta.currentInPlaceRestoreCondition = currentInPlaceRestoreString == "True"
+	}
+
+	return conditionMeta
+}
+
+// prepareClusterOriginConditions helps set the cluster origin conditions and reports if anything changed in this part of status.
+func (h *handler) prepareClusterOriginConditions(backup *v1.Backup) bool {
+	conditionChanged := false
+	conditionMeta := newBackupClusterOriginConditionMeta(h.kubeSystemNS, backup)
+
+	// Fist pass we only care to set BackupConditionClusterOrigin based on if the context is there
+	if !conditionMeta.hasCurrentOriginCondition || conditionMeta.currentOriginCondition != conditionMeta.hasClusterOriginID {
+		conditionChanged = true
+		condition.Cond(v1.BackupConditionClusterOrigin).SetStatusBool(backup, conditionMeta.hasClusterOriginID)
+
+		if conditionMeta.hasClusterOriginID {
+			condition.Cond(v1.BackupConditionClusterOrigin).Message(backup, "Backup has cluster UID attached.")
+		} else {
+			condition.Cond(v1.BackupConditionClusterOrigin).Message(backup, "No cluster UID attached to backup.")
+		}
+	}
+
+	// Second pass, we care about the specifics of the ClusterOrigin to set the InPlaceRestore condition
+	if !conditionMeta.hasClusterOriginID {
+		// When annotation is missing, we'll mark as unable to determine
+		condition.Cond(v1.BackupConditionInPlaceRestore).SetStatusBool(backup, false)
+		condition.Cond(v1.BackupConditionInPlaceRestore).Message(backup, "Unable to determine if in-place Restore is viable.")
+	}
+
+	if !conditionMeta.hasInPlaceRestoreCondition || conditionMeta.canInPlaceRestore != conditionMeta.currentInPlaceRestoreCondition {
+		conditionChanged = true
+		condition.Cond(v1.BackupConditionInPlaceRestore).SetStatusBool(backup, conditionMeta.canInPlaceRestore)
+		if conditionMeta.canInPlaceRestore {
+			condition.Cond(v1.BackupConditionInPlaceRestore).Message(backup, "In-place Restore appears viable.")
+		} else {
+			condition.Cond(v1.BackupConditionInPlaceRestore).Message(backup, "In-place Restore does not appear viable.")
+		}
+	}
+
+	// When the annotation is present and not changed
+	return conditionChanged
+}

--- a/pkg/controllers/backup/controller.go
+++ b/pkg/controllers/backup/controller.go
@@ -102,17 +102,17 @@ func (h *handler) OnBackupChange(_ string, backup *v1.Backup) (*v1.Backup, error
 			// Backup CR was meant for one-time backup, and the backup has been completed. Probably here from UpdateStatus call
 			logrus.Infof("Backup CR %v has been processed for one-time backup, returning", backup.Name)
 			// This could also mean backup CR was updated from recurring to one-time, in which case observedGeneration needs to be updated
-			updBackupStatus := false
+			shouldUpdateStatus := false
 			if backup.Generation != backup.Status.ObservedGeneration {
 				backup.Status.ObservedGeneration = backup.Generation
-				updBackupStatus = true
+				shouldUpdateStatus = true
 			}
 			// check if the backup-type needs to be changed too
 			if backup.Status.BackupType != "One-time" {
 				backup.Status.BackupType = "One-time"
-				updBackupStatus = true
+				shouldUpdateStatus = true
 			}
-			if updBackupStatus {
+			if shouldUpdateStatus {
 				return h.backups.UpdateStatus(backup)
 			}
 			return backup, nil

--- a/pkg/controllers/backup/controller.go
+++ b/pkg/controllers/backup/controller.go
@@ -39,7 +39,8 @@ type handler struct {
 	dynamicClient           dynamic.Interface
 	defaultBackupMountPath  string
 	defaultS3BackupLocation *v1.S3ObjectStore
-	kubeSystemNS            string
+	// TODO: rename to kubeSystemNamespaceUID; nit to improve clarity, it's not the string representation nor the NS resource
+	kubeSystemNS string
 }
 
 const DefaultRetentionCount = 10
@@ -79,6 +80,7 @@ func Register(
 		// fatal log here, because we need the kube-system ns UID while creating any backup file
 		logrus.Fatalf("Error getting namespace kube-system %v", err)
 	}
+	// TODO: rename to kubeSystemNamespaceUID; nit to improve clarity, it's not the string representation nor the NS resource
 	controller.kubeSystemNS = string(kubeSystemNS.UID)
 	// Register handlers
 	backups.OnChange(ctx, "backups", controller.OnBackupChange)
@@ -94,6 +96,7 @@ func (h *handler) OnBackupChange(_ string, backup *v1.Backup) (*v1.Backup, error
 		return h.setReconcilingCondition(backup, err)
 	}
 
+	// Handle updates made on Backup CRs with existing backup files
 	if backup.Status.LastSnapshotTS != "" {
 		if backup.Spec.Schedule == "" {
 			// Backup CR was meant for one-time backup, and the backup has been completed. Probably here from UpdateStatus call

--- a/pkg/controllers/backup/controller.go
+++ b/pkg/controllers/backup/controller.go
@@ -123,6 +123,9 @@ func (h *handler) OnBackupChange(_ string, backup *v1.Backup) (*v1.Backup, error
 			return backup, nil
 		}
 		if backup.Status.NextSnapshotAt != "" {
+			// TODO: Verify how recurring backups work after a migration today
+			//       Then decide how/where to call prepareClusterOriginConditions for that.
+
 			currTime := time.Now().Format(time.RFC3339)
 			logrus.Infof("Next snapshot is scheduled for: %v, current time: %v", backup.Status.NextSnapshotAt, currTime)
 

--- a/pkg/controllers/backup/controller.go
+++ b/pkg/controllers/backup/controller.go
@@ -75,7 +75,7 @@ func Register(
 	}
 
 	// Use the kube-system NS.UID as the unique ID for a cluster
-	kubeSystemNamespaceUID, err := util.FetchClusterUid(namespaces)
+	kubeSystemNamespaceUID, err := util.FetchClusterUID(namespaces)
 	if err != nil {
 		// fatal log here, because we need the kube-system ns UID while creating any backup file
 		logrus.Fatalf("Error getting namespace kube-system %v", err)

--- a/pkg/crds/crd.go
+++ b/pkg/crds/crd.go
@@ -59,7 +59,8 @@ func List() []crd.CRD {
 				WithColumn("Latest-Backup", ".status.filename").
 				WithColumn("ResourceSet", ".spec.resourceSetName").
 				WithCustomColumn(apiext.CustomResourceColumnDefinition{Name: "Age", Type: "date", JSONPath: ".metadata.creationTimestamp"}).
-				WithColumn("Status", ".status.conditions[?(@.type==\"Ready\")].message")
+				WithColumn("Status", ".status.conditions[?(@.type==\"Ready\")].message").
+				WithColumn("In-Place", ".status.conditions[?(@.type==\"InPlaceRestore\")].status")
 		}),
 		newCRD(&resources.Restore{}, func(c crd.CRD) crd.CRD {
 			return c.

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -75,7 +75,7 @@ func ErrList(e []error) error {
 	return nil
 }
 
-func FetchClusterUid(namespaces v1core.NamespaceController) (string, error) {
+func FetchClusterUID(namespaces v1core.NamespaceController) (string, error) {
 	kubesystemNamespace, err := namespaces.Get("kube-system", k8sv1.GetOptions{})
 	if err != nil {
 		return "", err

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -74,3 +74,12 @@ func ErrList(e []error) error {
 	}
 	return nil
 }
+
+func FetchClusterUid(namespaces v1core.NamespaceController) (string, error) {
+	kubesystemNamespace, err := namespaces.Get("kube-system", k8sv1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	return string(kubesystemNamespace.UID), nil
+}


### PR DESCRIPTION
This partial solves for https://github.com/rancher/backup-restore-operator/issues/612

However it's important to note that while I wrote an RFE for this too - the root here is seeking to fix a bug. The bug is that "BRO itself doesn't do anything to give indications when In-Place Restore is acceptable to use".

The short version of the fix, is we add a few new status details and expose them via `kubectl`. And later make a change to `rancher/dashboard` to ensure UI can also benefit from this new context by adding a column.

---

To be discussed:

- This change is very Backwards Compatible, can we ship a CRD change for the new status field in a `2.10.x` release?
  - Feels like it's a grey area - but, probably OK.
  - `k8s` seems to be OK with full on schema additions (of `spec` too) as long as they're optional/nullalble. This is hopefully less impactful since users cannot control `status`.
  - The current result on a cluster w/o CRD change is:
    -  is a new warning about `originCluster` not existing on status,
    - Status conditions are correctly set to represent unknown in-place viability.
- Do we want to explore supporting an even more Backwards friendly method of detecting origin ID's with Filename?
  - For the best UX, we will account for existing backups with UID in filename. In other words, once the CRD is updated with new status field we'll add the UID we find from the filename (or do nothing if not matching expected filename format).
