### PR TITLE
Add PSA configuration secret to provisioning resource set

### DIFF
--- a/charts/rancher-backup/files/default-resourceset-contents/provisioningv2.yaml
+++ b/charts/rancher-backup/files/default-resourceset-contents/provisioningv2.yaml
@@ -13,7 +13,7 @@
   kindsRegexp: "."
 - apiVersion: "v1"
   kindsRegexp: "^secrets$"
-  resourceNameRegexp: "machine-plan$|rke-state$|machine-state$|machine-driver-secret$|machine-provision$|^harvesterconfig|^registryconfig-auth|^harvester-cloud-provider-config"
+  resourceNameRegexp: "machine-plan$|rke-state$|machine-state$|machine-driver-secret$|machine-provision$|admission-configuration-psact$|^harvesterconfig|^registryconfig-auth|^harvester-cloud-provider-config"
   namespaces:
   - "fleet-default"
 - apiVersion: "v1"

--- a/charts/rancher-backup/files/sensitive-resourceset-contents/provisioningv2.yaml
+++ b/charts/rancher-backup/files/sensitive-resourceset-contents/provisioningv2.yaml
@@ -1,5 +1,5 @@
 - apiVersion: "v1"
   kindsRegexp: "^secrets$"
-  resourceNameRegexp: "machine-plan$|rke-state$|machine-state$|machine-driver-secret$|machine-provision$|^harvesterconfig|^registryconfig-auth|^harvester-cloud-provider-config"
+  resourceNameRegexp: "machine-plan$|rke-state$|machine-state$|machine-driver-secret$|machine-provision$|admission-configuration-psact$|^harvesterconfig|^registryconfig-auth|^harvester-cloud-provider-config"
   namespaces:
   - "fleet-default"

--- a/e2e/test/data/rancher-resource-set-full.yaml
+++ b/e2e/test/data/rancher-resource-set-full.yaml
@@ -296,7 +296,7 @@ resourceSelectors:
   
   - apiVersion: "v1"
     kindsRegexp: "^secrets$"
-    resourceNameRegexp: "machine-plan$|rke-state$|machine-state$|machine-driver-secret$|machine-provision$|^harvesterconfig|^registryconfig-auth|^harvester-cloud-provider-config"
+    resourceNameRegexp: "machine-plan$|rke-state$|machine-state$|machine-driver-secret$|machine-provision$|admission-configuration-psact$|^harvesterconfig|^registryconfig-auth|^harvester-cloud-provider-config"
     namespaces:
     - "fleet-default"
   


### PR DESCRIPTION
When a k3s/RKE2 cluster is created with a non-default PSA configuration template, the configuration from that template is then stored in a secret, which is used by the control plane planner.

This secret is only updated by the webhook when the provisioning cluster object is updated, and it wasn't included in the backups created from the default resource set, so after a migration the planner would get stuck in an error state until the secret was re-created manually.

The secret name is defined in the webhook [here](https://github.com/rancher/webhook/blob/v0.6.3/pkg/resources/provisioning.cattle.io/v1/cluster/mutator.go#L39).

This is not needed for RKE1 because in that case the configuration from the template is added to the management v3 cluster object, which is already backed-up, and not a secret.

Issue: https://github.com/rancher/rancher/issues/48884