### PR TITLE
Add label to track provisioning secrets

### DIFF
--- a/charts/rancher-backup/files/default-resourceset-contents/provisioningv2.yaml
+++ b/charts/rancher-backup/files/default-resourceset-contents/provisioningv2.yaml
@@ -13,9 +13,13 @@
   kindsRegexp: "."
 - apiVersion: "v1"
   kindsRegexp: "^secrets$"
-  resourceNameRegexp: "machine-plan$|rke-state$|machine-state$|machine-driver-secret$|machine-provision$|admission-configuration-psact$|^harvesterconfig|^registryconfig-auth|^harvester-cloud-provider-config"
   namespaces:
   - "fleet-default"
+  labelSelectors:
+    matchExpressions:
+      - key: "provisioning.cattle.io/managed"
+        operator: "In"
+        values: ["true"]
 - apiVersion: "v1"
   kindsRegexp: "^configmaps$"
   resourceNames:


### PR DESCRIPTION
Replaces picking the Provisioning Secrets by name to instead picking them by label.