### PR TITLE
[main] Add support for a `FieldSelector` in the ResourceSet

### DIFF
--- a/charts/rancher-backup-crd/templates/resourceset.yaml
+++ b/charts/rancher-backup-crd/templates/resourceset.yaml
@@ -49,6 +49,12 @@ spec:
                 excludeResourceNameRegexp:
                   nullable: true
                   type: string
+                fieldSelectors:
+                  additionalProperties:
+                    nullable: true
+                    type: string
+                  nullable: true
+                  type: object
                 kinds:
                   items:
                     nullable: true

--- a/charts/rancher-backup/files/default-resourceset-contents/provisioningv2.yaml
+++ b/charts/rancher-backup/files/default-resourceset-contents/provisioningv2.yaml
@@ -13,7 +13,7 @@
   kindsRegexp: "."
 - apiVersion: "v1"
   kindsRegexp: "^secrets$"
-  resourceNameRegexp: "machine-plan$|rke-state$|machine-state$|machine-driver-secret$|machine-provision$|admission-configuration-psact$|^harvesterconfig|^registryconfig-auth|^harvester-cloud-provider-config"
+  resourceNameRegexp: "machine-driver-secret$|machine-provision$|admission-configuration-psact$|^harvesterconfig|^registryconfig-auth|^harvester-cloud-provider-config"
   namespaces:
   - "fleet-default"
 - apiVersion: "v1"
@@ -21,3 +21,21 @@
   resourceNames:
     - "provisioning-log"
   namespaceRegexp: "^c-m-"
+- apiVersion: "v1"
+  kindsRegexp: "^secrets$"
+  namespaces:
+   - "fleet-default"
+  fieldSelectors:
+    "type": "rke.cattle.io/machine-plan"
+- apiVersion: "v1"
+  kindsRegexp: "^secrets$"
+  namespaces:
+   - "fleet-default"
+  fieldSelectors:
+    "type": "rke.cattle.io/cluster-state"
+- apiVersion: "v1"
+  kindsRegexp: "^secrets$"
+  namespaces:
+   - "fleet-default"
+  fieldSelectors:
+    "type": "rke.cattle.io/machine-state"

--- a/charts/rancher-backup/files/sensitive-resourceset-contents/provisioningv2.yaml
+++ b/charts/rancher-backup/files/sensitive-resourceset-contents/provisioningv2.yaml
@@ -1,5 +1,23 @@
 - apiVersion: "v1"
   kindsRegexp: "^secrets$"
-  resourceNameRegexp: "machine-plan$|rke-state$|machine-state$|machine-driver-secret$|machine-provision$|admission-configuration-psact$|^harvesterconfig|^registryconfig-auth|^harvester-cloud-provider-config"
+  resourceNameRegexp: "machine-driver-secret$|machine-provision$|admission-configuration-psact$|^harvesterconfig|^registryconfig-auth|^harvester-cloud-provider-config"
   namespaces:
   - "fleet-default"
+- apiVersion: "v1"
+  kindsRegexp: "^secrets$"
+  namespaces:
+   - "fleet-default"
+  fieldSelectors:
+      "type": "rke.cattle.io/machine-plan"
+- apiVersion: "v1"
+  kindsRegexp: "^secrets$"
+  namespaces:
+   - "fleet-default"
+  fieldSelectors:
+      "type": "rke.cattle.io/cluster-state"
+- apiVersion: "v1"
+  kindsRegexp: "^secrets$"
+  namespaces:
+   - "fleet-default"
+  fieldSelectors:
+      "type": "rke.cattle.io/machine-state"

--- a/pkg/apis/resources.cattle.io/v1/types.go
+++ b/pkg/apis/resources.cattle.io/v1/types.go
@@ -3,6 +3,7 @@ package v1
 import (
 	"github.com/rancher/wrangler/v3/pkg/genericcondition"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 )
 
 var (
@@ -68,6 +69,7 @@ type ResourceSelector struct {
 	Namespaces                []string              `json:"namespaces,omitempty"`
 	NamespaceRegexp           string                `json:"namespaceRegexp,omitempty"`
 	LabelSelectors            *metav1.LabelSelector `json:"labelSelectors,omitempty"`
+	FieldSelectors            fields.Set            `json:"fieldSelectors,omitempty"`
 	ExcludeKinds              []string              `json:"excludeKinds,omitempty"`
 	ExcludeResourceNameRegexp string                `json:"excludeResourceNameRegexp,omitempty"`
 }

--- a/pkg/apis/resources.cattle.io/v1/zz_generated_deepcopy.go
+++ b/pkg/apis/resources.cattle.io/v1/zz_generated_deepcopy.go
@@ -24,6 +24,7 @@ package v1
 import (
 	genericcondition "github.com/rancher/wrangler/v3/pkg/genericcondition"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fields "k8s.io/apimachinery/pkg/fields"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -168,6 +169,13 @@ func (in *ResourceSelector) DeepCopyInto(out *ResourceSelector) {
 		in, out := &in.LabelSelectors, &out.LabelSelectors
 		*out = new(metav1.LabelSelector)
 		(*in).DeepCopyInto(*out)
+	}
+	if in.FieldSelectors != nil {
+		in, out := &in.FieldSelectors, &out.FieldSelectors
+		*out = make(fields.Set, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
 	}
 	if in.ExcludeKinds != nil {
 		in, out := &in.ExcludeKinds, &out.ExcludeKinds

--- a/pkg/resourcesets/collector.go
+++ b/pkg/resourcesets/collector.go
@@ -15,6 +15,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	k8sv1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	k8sEncryptionconfig "k8s.io/apiserver/pkg/server/options/encryptionconfig"
 	"k8s.io/apiserver/pkg/storage/value"
@@ -128,14 +129,14 @@ func (h *ResourceHandler) gatherObjectsForResource(ctx context.Context, res k8sv
 	gvr := gv.WithResource(res.Name)
 	dr := h.DynamicClient.Resource(gvr)
 
-	// only resources that match name+namespace+label combination will be backed up, so we can filter in any order
+	// only resources that match name+namespace and label/field selector combination will be backed up, so we can filter in any order
 	// however, in practice filtering by label happens at an API level when we paginate the resources (creating our initial list)
-	filteredByLabel, err := h.filterByLabel(ctx, dr, filter)
+	resourcesFromAPIServer, err := h.fetchResourcesFromAPIServer(ctx, dr, filter)
 	if err != nil {
 		return nil, err
 	}
 
-	filteredByName, err := h.filterByName(filter, filteredByLabel.Items)
+	filteredByName, err := h.filterByName(filter, resourcesFromAPIServer.Items)
 	if err != nil {
 		return nil, err
 	}
@@ -146,9 +147,10 @@ func (h *ResourceHandler) gatherObjectsForResource(ctx context.Context, res k8sv
 	return filteredByName, nil
 }
 
-// filterByLabel actually uses a label selector to fetch, unroll, and return the initial list of objects
-func (h *ResourceHandler) filterByLabel(ctx context.Context, dr dynamic.ResourceInterface, filter v1.ResourceSelector) (*unstructured.UnstructuredList, error) {
+// fetchResourcesFromAPIServer uses a label selector and/or field selector from the ResourceSelector to fetch, unroll, and return the initial list of objects
+func (h *ResourceHandler) fetchResourcesFromAPIServer(ctx context.Context, dr dynamic.ResourceInterface, filter v1.ResourceSelector) (*unstructured.UnstructuredList, error) {
 	var labelSelector string
+	var fieldSelector string
 
 	if filter.LabelSelectors != nil {
 		selector, err := k8sv1.LabelSelectorAsSelector(filter.LabelSelectors)
@@ -159,7 +161,12 @@ func (h *ResourceHandler) filterByLabel(ctx context.Context, dr dynamic.Resource
 		logrus.Debugf("Listing objects using label selector %v", labelSelector)
 	}
 
-	return unrollPaginatedListResult(ctx, dr, k8sv1.ListOptions{LabelSelector: labelSelector})
+	if filter.FieldSelectors != nil {
+		fieldSelector = fields.SelectorFromSet(filter.FieldSelectors).String()
+		logrus.Debugf("Listing objects using field selector %v", fieldSelector)
+	}
+
+	return unrollPaginatedListResult(ctx, dr, k8sv1.ListOptions{LabelSelector: labelSelector, FieldSelector: fieldSelector})
 }
 
 func (h *ResourceHandler) filterByKind(filter v1.ResourceSelector, apiResources []k8sv1.APIResource) ([]k8sv1.APIResource, error) {


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/48558

### Problem:
Certain very important secrets are not being backed up by the backup-restore operator when the cluster-name + pool-name gets to be longer than 63 characters, this is because [they fail to match the v2prov regex](https://github.com/rancher/backup-restore-operator/blob/4a35b5ea6009fb099322b709263f4b04b98501a7/charts/rancher-backup/files/default-resourceset-contents/provisioningv2.yaml#L14-L18). 

### Solution:
Add support for selecting resources via `fieldSelector` in order to be able to effectively filter on specific secret types that we care about. This will be useful for other "custom" secret types as well as being able to narrow things that have a certain label + fieldSelector. 

The solution is implemented by just tacking on a fieldSelector to the initial API listing if it is present. By default it selects everything mimicking old behavior (exactly like the label selector api).

### Alternatives:
- I did go down the route of limiting the secret name length [here](https://github.com/rancher/rancher/pull/49322) but that seems to introduce a lot of regression risk as well as feeling really hacky
- Changing rancher to use annotations/labels etc rather than just string names, but once again this would have high regression risk since we would effectively be completely changing how rancher looks up secrets pertaining to a cluster/pool for machine-state/machine-plan/cluster-state secrets

### Testing:
I added e2e integration tests for this which fetch the tarball and extract it into memory - and then validate that the custom-resource-set was used and backed up a single secret (and not the other one)