### PR TITLE
fix: Actually use the default resourcesets for rancher-resource-set-full

### DIFF
--- a/charts/rancher-backup/templates/rancher-resourceset-full.yaml
+++ b/charts/rancher-backup/templates/rancher-resourceset-full.yaml
@@ -8,7 +8,7 @@ controllerReferences:
     name: "rancher"
     namespace: "cattle-system"
 resourceSelectors:
-{{- range $path, $_ := .Files.Glob "files/basic-resourceset-contents/*.yaml" -}}
+{{- range $path, $_ := .Files.Glob "files/default-resourceset-contents/*.yaml" -}}
   {{- $.Files.Get $path | nindent 2 -}}
 {{- end -}}
 {{- range $path, $_ := .Files.Glob "files/sensitive-resourceset-contents/*.yaml" -}}


### PR DESCRIPTION
The template generation for the `rancher-resource-set-full` was consuming the topic `basic-resourceset-contents` plus the `sensitive-resourceset-contents`, while it should consume the `default-resourceset-contents` plus the `sensitive-resourceset-contents`.

The `default-resourceset-contents` and `sensitive-resourceset-contents` don't have a full intersection, there are Secrets that are covered by one that aren't covered by other.