### PR TITLE
Backup ext kubeconfigs backing configmaps

### DIFF
--- a/charts/rancher-backup/files/basic-resourceset-contents/rancher.yaml
+++ b/charts/rancher-backup/files/basic-resourceset-contents/rancher.yaml
@@ -11,6 +11,14 @@
   kindsRegexp: "^configmaps$"
   namespaces:
     - "cattle-system"
+- apiVersion: "v1"
+  kindsRegexp: "^configmaps$"
+  namespaceRegexp: "^cattle-"
+  labelSelectors:
+    matchExpressions:
+      - key: "cattle.io/kind"
+        operator: "In"
+        values: [ "kubeconfig" ]
 - apiVersion: "rbac.authorization.k8s.io/v1"
   kindsRegexp: "^roles$|^rolebindings$"
   namespaceRegexp: "^cattle-|^p-|^c-|^local$|^user-|^u-"


### PR DESCRIPTION
A new imperative resource kubeconfigs.ext.cattle.io uses configmaps in `cattle-tokens` namespace to store its state.

This PR adds them to the basic resource set.