### PR TITLE
[main] Fix version meta

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -23,6 +23,27 @@ builds:
         - -trimpath
       env:
         - CGO_ENABLED=0
+
+  # macOS build, only when GOOS_DARWIN_DEV is set
+    - id: backup-restore-operator-darwin
+      main: ./cmd/operator/main.go
+      goos:
+        - darwin
+      goarch:
+        - amd64
+        - arm64
+      binary: backup-restore-operator
+      ldflags:
+        - -s
+        - -X github.com/rancher/backup-restore-operator/cmd/operator/version.Version={{.Version}}
+        - -X github.com/rancher/backup-restore-operator/cmd/operator/version.GitCommit={{.Commit}}
+        - -X github.com/rancher/backup-restore-operator/cmd/operator/version.Date={{.Date}}
+      flags:
+        - -trimpath
+      env:
+        - CGO_ENABLED=0
+      skip: '{{ not (index .Env "GOOS_DARWIN_DEV") }}'
+
 archives:
     - id: backup-restore-operator
       builds:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -17,7 +17,7 @@ builds:
         - -static
         - -s
         - -X github.com/rancher/backup-restore-operator/cmd/operator/version.Version={{.Version}}
-        - -X github.com/rancher/backup-restore-operator/cmd/operator/version.Commit={{.Commit}}
+        - -X github.com/rancher/backup-restore-operator/cmd/operator/version.GitCommit={{.Commit}}
         - -X github.com/rancher/backup-restore-operator/cmd/operator/version.Date={{.Date}}
       flags:
         - -trimpath

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -53,7 +53,7 @@ func main() {
 		logrus.Tracef("Loglevel set to [%v]", logrus.TraceLevel)
 	}
 
-	logrus.Infof("Starting backup-restore controller version %s (%s) [built at %s]", version.Version, version.GitCommit, version.Date)
+	logrus.Infof("Starting backup-restore-operator version %s (%s) [built at %s]", version.Version, version.GitCommit, version.Date)
 	ctx := signals.SetupSignalContext()
 	restKubeConfig, err := kubeconfig.GetNonInteractiveClientConfig(KubeConfig).ClientConfig()
 	if err != nil {

--- a/scripts/build
+++ b/scripts/build
@@ -10,7 +10,8 @@ if [ "$(uname)" = "Linux" ]; then
     OTHER_LINKFLAGS="-extldflags -static -s -w"
 fi
 
-LINKFLAGS="-X github.com/rancher/backup-restore-operator/cmd/operator/main.Version=$VERSION"
-LINKFLAGS="-X github.com/rancher/backup-restore-operator/cmd/operator/main.GitCommit=$COMMIT $LINKFLAGS"
+LINKFLAGS="-X github.com/rancher/backup-restore-operator/cmd/operator/version.Version=$VERSION"
+LINKFLAGS="-X github.com/rancher/backup-restore-operator/cmd/operator/version.GitCommit=$COMMIT $LINKFLAGS"
+LINKFLAGS="-X github.com/rancher/backup-restore-operator/cmd/operator/version.Date=$(date -u +"%Y-%m-%dT%H:%M:%SZ") $LINKFLAGS"
 
 CGO_ENABLED=0 go build -ldflags "$LINKFLAGS $OTHER_LINKFLAGS" -o "bin/backup-restore-operator" ./cmd/operator/main.go


### PR DESCRIPTION
I noticed in a recent bug report from a user (and/or QA, forget where I saw it first) that the BRO version was 0.0.0 and no git hash info was set. And as I worked on the SCC operator I was referencing BRO code and things finally clicked. So here is the fix to ensure that future builds have proper version info.

This PR follows up on previous attempt to fix in 65f00b672c58c51052225a20dd4481bc526c2a89 via https://github.com/rancher/backup-restore-operator/pull/791.
Where that PR (fixing a different bug) included a partial fix for this issue.