### PR TITLE
[7.x backport] Fix version meta

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -16,11 +16,34 @@ builds:
         - -extldflags
         - -static
         - -s
-        - -X github.com/rancher/backup-restore-operator/cmd/operator/main.Version={{.Version}} -X github.com/rancher/backup-restore-operator/cmd/operator/main.GitCommit={{.Commit}}
+        - -X github.com/rancher/backup-restore-operator/cmd/operator/version.Version={{.Version}}
+        - -X github.com/rancher/backup-restore-operator/cmd/operator/version.GitCommit={{.Commit}}
+        - -X github.com/rancher/backup-restore-operator/cmd/operator/version.Date={{.Date}}
       flags:
         - -trimpath
       env:
         - CGO_ENABLED=0
+
+  # macOS build, only when GOOS_DARWIN_DEV is set
+    - id: backup-restore-operator-darwin
+      main: ./cmd/operator/main.go
+      goos:
+        - darwin
+      goarch:
+        - amd64
+        - arm64
+      binary: backup-restore-operator
+      ldflags:
+        - -s
+        - -X github.com/rancher/backup-restore-operator/cmd/operator/version.Version={{.Version}}
+        - -X github.com/rancher/backup-restore-operator/cmd/operator/version.GitCommit={{.Commit}}
+        - -X github.com/rancher/backup-restore-operator/cmd/operator/version.Date={{.Date}}
+      flags:
+        - -trimpath
+      env:
+        - CGO_ENABLED=0
+      skip: '{{ not (index .Env "GOOS_DARWIN_DEV") }}'
+
 archives:
     - id: backup-restore-operator
       builds:

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ This is the current branch strategy for `rancher/backup-restore-operator`, it ma
 | Branch         | Tag      | Rancher                |
 |----------------|----------|------------------------|
 | `main`         | `head`   | `main` branch (`head`) |
+| `release/v7.x` | `v7.x.x` | `v2.11.x`              |
 | `release/v6.x` | `v6.x.x` | `v2.10.x`              |
 | `release/v5.0` | `v5.x.x` | `v2.9.x`               |
 | `release/v4.0` | `v4.x.x` | `v2.8.x`               |

--- a/charts/rancher-backup/values.yaml
+++ b/charts/rancher-backup/values.yaml
@@ -54,7 +54,7 @@ global:
       enabled: false # PSP enablement should default to false
   kubectl:
     repository: rancher/kuberlr-kubectl
-    tag: v4.0.2
+    tag: v4.0.3
 
 ## Node labels for pod assignment
 ## Ref: https://kubernetes.io/docs/user-guide/node-selection/

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"os"
 
+	"github.com/rancher/backup-restore-operator/cmd/operator/version"
 	"github.com/rancher/backup-restore-operator/pkg/operator"
 	backuputil "github.com/rancher/backup-restore-operator/pkg/util"
 	"github.com/rancher/wrangler/v3/pkg/kubeconfig"
@@ -16,8 +17,6 @@ const (
 )
 
 var (
-	Version                         = "v0.0.0-dev"
-	GitCommit                       = "HEAD"
 	LocalBackupStorageLocation      = "/var/lib/backups" // local within the pod, this is the mountPath for PVC
 	KubeConfig                      string
 	OperatorPVEnabled               string
@@ -51,7 +50,7 @@ func main() {
 		logrus.Tracef("Loglevel set to [%v]", logrus.TraceLevel)
 	}
 
-	logrus.Infof("Starting backup-restore controller version %s (%s)", Version, GitCommit)
+	logrus.Infof("Starting backup-restore-operator version %s (%s) [built at %s]", version.Version, version.GitCommit, version.Date)
 	ctx := signals.SetupSignalContext()
 	restKubeConfig, err := kubeconfig.GetNonInteractiveClientConfig(KubeConfig).ClientConfig()
 	if err != nil {

--- a/cmd/operator/version/version.go
+++ b/cmd/operator/version/version.go
@@ -1,0 +1,7 @@
+package version
+
+var (
+	Version   = "v0.0.0-dev"
+	GitCommit = "HEAD"
+	Date      = "unknown"
+)

--- a/scripts/build
+++ b/scripts/build
@@ -10,7 +10,8 @@ if [ "$(uname)" = "Linux" ]; then
     OTHER_LINKFLAGS="-extldflags -static -s -w"
 fi
 
-LINKFLAGS="-X github.com/rancher/backup-restore-operator/cmd/operator/main.Version=$VERSION"
-LINKFLAGS="-X github.com/rancher/backup-restore-operator/cmd/operator/main.GitCommit=$COMMIT $LINKFLAGS"
+LINKFLAGS="-X github.com/rancher/backup-restore-operator/cmd/operator/version.Version=$VERSION"
+LINKFLAGS="-X github.com/rancher/backup-restore-operator/cmd/operator/version.GitCommit=$COMMIT $LINKFLAGS"
+LINKFLAGS="-X github.com/rancher/backup-restore-operator/cmd/operator/version.Date=$(date -u +"%Y-%m-%dT%H:%M:%SZ") $LINKFLAGS"
 
 CGO_ENABLED=0 go build -ldflags "$LINKFLAGS $OTHER_LINKFLAGS" -o "bin/backup-restore-operator" ./cmd/operator/main.go


### PR DESCRIPTION
A backport of: https://github.com/rancher/backup-restore-operator/pull/798

Plus rolling in a remote `rancher/charts` patch here so we can remove it from charts repo.