### PR TITLE
feat: add extraObjects + resources to the Helm Chart

### DIFF
--- a/charts/rancher-backup/README.md
+++ b/charts/rancher-backup/README.md
@@ -49,6 +49,8 @@ The following table lists the configurable parameters of the rancher-backup char
 | affinity | https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity | {} |
 | serviceAccount.annotations | Annotations to apply to created service account | {} |
 | global.cattle.psp.enabled | Enable or disable PSPs in the chart | false |
+| resources | CPU and memory resource requests and limits for the backup-restore-operator container | {} |
+| extraObjects | Array of additional Kubernetes objects managed by the release | [] |
 
 -----
 

--- a/charts/rancher-backup/templates/deployment.yaml
+++ b/charts/rancher-backup/templates/deployment.yaml
@@ -42,6 +42,10 @@ spec:
         imagePullPolicy: {{ default "Always" .Values.imagePullPolicy }}
         securityContext:
           {{- include "securityContext" . | nindent 10 }}
+        {{- with .Values.resources }}
+        resources:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         ports:
         - containerPort: 8080
         args:

--- a/charts/rancher-backup/templates/extra-objects.yaml
+++ b/charts/rancher-backup/templates/extra-objects.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraObjects }}
+---
+{{ toYaml . }}
+{{- end }} 

--- a/charts/rancher-backup/tests/deployment_test.yaml
+++ b/charts/rancher-backup/tests/deployment_test.yaml
@@ -226,3 +226,60 @@ tests:
   - equal:
       path: spec.template.spec.imagePullSecrets[0].name
       value: "pull-secret"
+
+- it: should not set default resources
+  template: deployment.yaml
+  asserts:
+  - isNull:
+      path: spec.template.spec.containers[0].resources
+
+- it: should set resources with requests and limits
+  set:
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
+  template: deployment.yaml
+  asserts:
+  - equal:
+      path: spec.template.spec.containers[0].resources
+      value:
+        requests:
+          cpu: 100m
+          memory: 128Mi
+        limits:
+          cpu: 500m
+          memory: 512Mi
+
+- it: should set resources with only requests
+  set:
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+  template: deployment.yaml
+  asserts:
+  - equal:
+      path: spec.template.spec.containers[0].resources
+      value:
+        requests:
+          cpu: 100m
+          memory: 128Mi
+
+- it: should set resources with only limits
+  set:
+    resources:
+      limits:
+        cpu: 500m
+        memory: 512Mi
+  template: deployment.yaml
+  asserts:
+  - equal:
+      path: spec.template.spec.containers[0].resources
+      value:
+        limits:
+          cpu: 500m
+          memory: 512Mi

--- a/charts/rancher-backup/tests/extra-objects_test.yaml
+++ b/charts/rancher-backup/tests/extra-objects_test.yaml
@@ -1,0 +1,23 @@
+suite: Test extra objects
+templates:
+- extra-objects.yaml
+tests:
+- it: should create ConfigMap from extraObjects
+  set:
+    extraObjects:
+      - apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: test-config
+        data:
+          key: value
+  template: extra-objects.yaml
+  asserts:
+  - hasDocuments:
+      count: 1
+  - contains:
+      kind: ConfigMap
+      metadata:
+        name: test-config
+      data:
+        key: value

--- a/charts/rancher-backup/values.yaml
+++ b/charts/rancher-backup/values.yaml
@@ -125,7 +125,7 @@ resources: {}
   #   cpu: 2
   #   memory: 2Gi
 
-# Add extra objects to be created alongside the main deployment
+# Add extra objects to be managed by the release
 # This allows users to create Backups using the Backup CRD
 extraObjects: []
   # - apiVersion: resources.cattle.io/v1

--- a/charts/rancher-backup/values.yaml
+++ b/charts/rancher-backup/values.yaml
@@ -115,3 +115,22 @@ securityContext:
   ## Only processes running as 'root' can write to HostPath PVCs so Backups will fail in that scenario if not running as 'root'.
   ## However, this goes against Kubernetes security best practices and should be avoided whenever possible.
   runAsNonRoot: true
+
+# Add resources for the backup-restore-operator container
+resources: {}
+  # requests:
+  #   cpu: 1
+  #   memory: 1Gi
+  # limits:
+  #   cpu: 2
+  #   memory: 2Gi
+
+# Add extra objects to be created alongside the main deployment
+# This allows users to create Backups using the Backup CRD
+extraObjects: []
+  # - apiVersion: resources.cattle.io/v1
+  #   kind: Backup
+  #   spec:
+  #   resourceSetName: rancher-resource-set
+  #     retentionCount: 24
+  #     schedule: '@every 1h'


### PR DESCRIPTION
Added two small features to the helm chart : 

- extraObjects : to create more objects managed by the release (Backups)
  - we currently have to manage those objects using another system, this will ease the deployment
- resources : to define resources to the rancher-backup-operator container
  - we rely on limitRanges to set default limits, it should be provided by the deployment

Also fixes https://github.com/rancher/backup-restore-operator/issues/786
