### PR TITLE
 [main] Have backupType status update happen earlier in the controller loop - second approach

### DIFF
--- a/pkg/controllers/backup/controller.go
+++ b/pkg/controllers/backup/controller.go
@@ -119,17 +119,8 @@ func (h *handler) OnBackupChange(_ string, backup *v1.Backup) (*v1.Backup, error
 		return backupWithType, nil
 	}
 
-	validatedBackup := backup.DeepCopy()
-	if err = h.validateBackupSpec(validatedBackup); err != nil {
-		return h.setReconcilingCondition(validatedBackup, err)
-	}
-
-	if !reflect.DeepEqual(validatedBackup, backup) {
-		if validatedBackup, err = h.backups.Update(validatedBackup); err != nil {
-			return h.setReconcilingCondition(validatedBackup, err)
-		}
-
-		return validatedBackup, nil
+	if err = h.validateBackupSpec(backup); err != nil {
+		return h.setReconcilingCondition(backup, err)
 	}
 
 	if backup.Status.LastSnapshotTS != "" {

--- a/pkg/controllers/backup/controller.go
+++ b/pkg/controllers/backup/controller.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"time"
 
@@ -44,7 +45,10 @@ type handler struct {
 	encryptionProviderPath  string
 }
 
-const DefaultRetentionCount = 10
+const (
+	DefaultRetentionCountRecurring = 10
+	DefaultRetentionCountOneTime   = 1
+)
 
 func Register(
 	ctx context.Context,
@@ -102,21 +106,33 @@ func (h *handler) OnBackupChange(_ string, backup *v1.Backup) (*v1.Backup, error
 		logrus.Debugf("Backup %s has already been processed, skipping it", backup.Name)
 		return backup, nil
 	}
+
 	logrus.Infof("Processing backup %v", backup.Name)
 
-	if err = h.validateBackupSpec(backup); err != nil {
-		return h.setReconcilingCondition(backup, err)
+	backupWithType := backup.DeepCopy()
+	h.setBackupType(backupWithType)
+	if !reflect.DeepEqual(backupWithType, backup) {
+		if backupWithType, err = h.backups.UpdateStatus(backupWithType); err != nil {
+			return h.setReconcilingCondition(backupWithType, err)
+		}
+
+		return backupWithType, nil
+	}
+
+	validatedBackup := backup.DeepCopy()
+	if err = h.validateBackupSpec(validatedBackup); err != nil {
+		return h.setReconcilingCondition(validatedBackup, err)
+	}
+
+	if !reflect.DeepEqual(validatedBackup, backup) {
+		if validatedBackup, err = h.backups.Update(validatedBackup); err != nil {
+			return h.setReconcilingCondition(validatedBackup, err)
+		}
+
+		return validatedBackup, nil
 	}
 
 	if backup.Status.LastSnapshotTS != "" {
-		if backup.Spec.Schedule == "" { // one-time backup
-			// This means backup CR was updated from recurring to one-time, in which case observedGeneration needs to be updated
-			backup.Status.ObservedGeneration = backup.Generation
-			backup.Status.BackupType = v1.OneTimeBackupType
-
-			logrus.Infof("Updating backup %s from recurring to one-time", backup.Name)
-			return h.backups.UpdateStatus(backup)
-		}
 		if backup.Status.NextSnapshotAt != "" {
 			currTime := time.Now().Format(time.RFC3339)
 			logrus.Infof("Next snapshot is scheduled for: %v, current time: %v", backup.Status.NextSnapshotAt, currTime)
@@ -206,9 +222,6 @@ func (h *handler) OnBackupChange(_ string, backup *v1.Backup) (*v1.Backup, error
 			backup.Status.NextSnapshotAt = nextBackupAt.Format(time.RFC3339)
 			after := nextBackupAt.Sub(time.Now())
 			h.backups.EnqueueAfter(backup.Name, after)
-			backup.Status.BackupType = v1.RecurringBackupType
-		} else {
-			backup.Status.BackupType = v1.OneTimeBackupType
 		}
 		backup.Status.ObservedGeneration = backup.Generation
 		backup.Status.StorageLocation = storageLocationType
@@ -316,16 +329,31 @@ func (h *handler) performBackup(backup *v1.Backup, tmpBackupPath, backupFileName
 	return nil
 }
 
+func (h *handler) setBackupType(backup *v1.Backup) {
+	// Only checking if Schedule is set to determine the backup type, actual validation happens later in validateBackupSpec
+	if backup.Spec.Schedule == "" {
+		backup.Status.BackupType = v1.OneTimeBackupType
+	} else {
+		backup.Status.BackupType = v1.RecurringBackupType
+	}
+}
+
 func (h *handler) validateBackupSpec(backup *v1.Backup) error {
-	if backup.Spec.Schedule != "" {
+	logrus.Infof("backuptype set to: %v for %s", backup.Status.BackupType, backup.Name)
+
+	if backup.Status.BackupType == v1.RecurringBackupType {
 		_, err := cron.ParseStandard(backup.Spec.Schedule)
 		if err != nil {
 			return fmt.Errorf("error parsing invalid cron string for schedule: %v", err)
 		}
 		if backup.Spec.RetentionCount == 0 {
-			backup.Spec.RetentionCount = DefaultRetentionCount
+			backup.Spec.RetentionCount = DefaultRetentionCountRecurring
 		}
+	} else {
+		backup.Spec.RetentionCount = DefaultRetentionCountOneTime
 	}
+
+	logrus.Infof("retentionCount set to: %v for %s", backup.Spec.RetentionCount, backup.Name)
 	return nil
 }
 
@@ -370,5 +398,5 @@ func (h *handler) setReconcilingCondition(backup *v1.Backup, originalErr error) 
 
 // backupIsSingularAndComplete checks if the backup is a one-time backup and has not been modified
 func backupIsSingularAndComplete(backup *v1.Backup) bool {
-	return backup.Status.BackupType == "One-time" && backup.Generation == backup.Status.ObservedGeneration
+	return backup.Status.BackupType == v1.OneTimeBackupType && backup.Generation == backup.Status.ObservedGeneration
 }

--- a/pkg/controllers/backup/controller_test.go
+++ b/pkg/controllers/backup/controller_test.go
@@ -32,11 +32,90 @@ func TestGenerateBackupFilename(t *testing.T) {
 	assert.True(t, wantName.MatchString(filename), "Expected backup name in generated filename")
 }
 
-func TestValidateBackupSpecFail(t *testing.T) {
+func TestSetBackupTypeRecurring(t *testing.T) {
+	backupName := "ScheduleSet"
+
+	mockHandler := handler{}
+	backup := &v1.Backup{
+		Spec: v1.BackupSpec{
+			Schedule: "@midnight",
+		},
+	}
+	backup.SetName(backupName)
+
+	mockHandler.setBackupType(backup)
+
+	assert.Equal(t, v1.RecurringBackupType, backup.Status.BackupType, "Expected backupType 'Recurring' for backup %s", backup.Name)
+}
+
+func TestSetBackupTypeOneTime(t *testing.T) {
+	backupOneName := "ScheduleEmpty"
+	backupTwoName := "ScheduleNonExisting"
+
+	mockHandler := handler{}
+	backupOne := &v1.Backup{
+		Spec: v1.BackupSpec{
+			Schedule: "",
+		},
+	}
+	backupOne.SetName(backupOneName)
+
+	backupTwo := &v1.Backup{
+		Spec: v1.BackupSpec{},
+	}
+	backupTwo.SetName(backupTwoName)
+
+	mockHandler.setBackupType(backupOne)
+	mockHandler.setBackupType(backupTwo)
+
+	assert.Equal(t, v1.OneTimeBackupType, backupOne.Status.BackupType, "Expected backupType 'One-time' for backup %s", backupOne.Name)
+	assert.Equal(t, v1.OneTimeBackupType, backupTwo.Status.BackupType, "Expected backupType 'One-time' for backup %s", backupOne.Name)
+}
+
+func TestSetBackupTypeRecurringToOneTime(t *testing.T) {
+	backupName := "FromRecurringToOneTime"
+
+	// A backup with type Recurring but empty schedule means the user removed the schedule to turn it into a One-time backup
+	mockHandler := handler{}
+	backup := &v1.Backup{
+		Spec: v1.BackupSpec{
+			Schedule: "",
+		},
+		Status: v1.BackupStatus{
+			BackupType: v1.RecurringBackupType,
+		},
+	}
+	backup.SetName(backupName)
+
+	mockHandler.setBackupType(backup)
+
+	assert.Equal(t, v1.OneTimeBackupType, backup.Status.BackupType, "Expected backupType 'One-time' for backup %s", backup.Name)
+}
+
+func TestSetBackupTypeOneTimeToRecurring(t *testing.T) {
+	backupName := "FromOneTimeToRecurring"
+
+	// A backup with type One-time but non-empty schedule means the user added the schedule to turn it into a Recurring backup
+	mockHandler := handler{}
+	backup := &v1.Backup{
+		Spec: v1.BackupSpec{
+			Schedule: "@midnight",
+		},
+		Status: v1.BackupStatus{
+			BackupType: v1.OneTimeBackupType,
+		},
+	}
+	backup.SetName(backupName)
+
+	mockHandler.setBackupType(backup)
+
+	assert.Equal(t, v1.RecurringBackupType, backup.Status.BackupType, "Expected backupType 'Recurring' for backup %s", backup.Name)
+}
+
+func TestValidateBackupSpecFailByInvalidCron(t *testing.T) {
 	backupName := "TestName"
 
 	mockHandler := handler{}
-
 	backup := &v1.Backup{
 		Status: v1.BackupStatus{
 			BackupType: v1.RecurringBackupType,
@@ -72,6 +151,49 @@ func TestValidateBackupSpecPass(t *testing.T) {
 	err := mockHandler.validateBackupSpec(backup)
 
 	require.NoError(t, err, "Error when Validating backup spec")
+	require.Equal(t, int64(DefaultRetentionCountRecurring), backup.Spec.RetentionCount)
+}
+
+func TestValidateBackupSpecPassNonDefaultRetention(t *testing.T) {
+	// Expected output: TestName-TestNamespace-2023-05-08T13-40-33-04-00
+	// The timestamp is based on time.Now() so we don't check for it explicitly
+	backupOneName := "NonDefaultRetentionCount"
+	backupTwoName := "InvalidRetentionCount"
+
+	var arbitraryRetentionCount int64 = 7
+	var invalidRetentionCount int64 = 0
+
+	mockHandler := handler{}
+
+	backupOne := &v1.Backup{
+		Status: v1.BackupStatus{
+			BackupType: v1.RecurringBackupType,
+		},
+		Spec: v1.BackupSpec{
+			Schedule:       "0 0 * * *",
+			RetentionCount: arbitraryRetentionCount,
+		},
+	}
+	backupOne.SetName(backupOneName)
+
+	backupTwo := &v1.Backup{
+		Status: v1.BackupStatus{
+			BackupType: v1.RecurringBackupType,
+		},
+		Spec: v1.BackupSpec{
+			Schedule:       "0 0 * * *",
+			RetentionCount: invalidRetentionCount,
+		},
+	}
+	backupTwo.SetName(backupTwoName)
+
+	errOne := mockHandler.validateBackupSpec(backupOne)
+	errTwo := mockHandler.validateBackupSpec(backupTwo)
+
+	require.NoError(t, errOne, "Error when Validating backup spec for backup %s", backupOne.Name)
+	require.NoError(t, errTwo, "Error when Validating backup spec for backup %s", backupTwo.Name)
+	require.Equal(t, arbitraryRetentionCount, backupOne.Spec.RetentionCount, "Expected backup %s to maintain the arbitrary retentionCount", backupOne.Name)
+	require.Equal(t, int64(DefaultRetentionCountRecurring), backupTwo.Spec.RetentionCount, "Expected backup %s to have retentionCount set to default", backupTwo.Name)
 }
 
 func TestValidateBackupSpecOneTime(t *testing.T) {
@@ -89,7 +211,28 @@ func TestValidateBackupSpecOneTime(t *testing.T) {
 	err := mockHandler.validateBackupSpec(backup)
 
 	require.NoError(t, err, "Error when Validating backup spec")
-	require.Equal(t, backup.Spec.RetentionCount, int64(1))
+	require.Equal(t, backup.Spec.RetentionCount, int64(DefaultRetentionCountOneTime))
+}
+
+func TestValidateBackupSpecOneTimeNonDefaultRetention(t *testing.T) {
+	backupName := "NonDefaultRetentionCount"
+
+	mockHandler := handler{}
+
+	backup := &v1.Backup{
+		Status: v1.BackupStatus{
+			BackupType: v1.OneTimeBackupType,
+		},
+		Spec: v1.BackupSpec{
+			RetentionCount: 10,
+		},
+	}
+	backup.SetName(backupName)
+
+	err := mockHandler.validateBackupSpec(backup)
+
+	require.NoError(t, err, "Error when Validating backup spec")
+	require.Equal(t, backup.Spec.RetentionCount, int64(DefaultRetentionCountOneTime))
 }
 
 func TestBackupIsSingularAndComplete(t *testing.T) {

--- a/pkg/controllers/backup/controller_test.go
+++ b/pkg/controllers/backup/controller_test.go
@@ -38,6 +38,9 @@ func TestValidateBackupSpecFail(t *testing.T) {
 	mockHandler := handler{}
 
 	backup := &v1.Backup{
+		Status: v1.BackupStatus{
+			BackupType: v1.RecurringBackupType,
+		},
 		Spec: v1.BackupSpec{
 			Schedule: "kldsnd",
 		},
@@ -57,6 +60,9 @@ func TestValidateBackupSpecPass(t *testing.T) {
 	mockHandler := handler{}
 
 	backup := &v1.Backup{
+		Status: v1.BackupStatus{
+			BackupType: v1.RecurringBackupType,
+		},
 		Spec: v1.BackupSpec{
 			Schedule: "0 0 * * *",
 		},
@@ -66,6 +72,24 @@ func TestValidateBackupSpecPass(t *testing.T) {
 	err := mockHandler.validateBackupSpec(backup)
 
 	require.NoError(t, err, "Error when Validating backup spec")
+}
+
+func TestValidateBackupSpecOneTime(t *testing.T) {
+	backupName := "TestName"
+
+	mockHandler := handler{}
+
+	backup := &v1.Backup{
+		Status: v1.BackupStatus{
+			BackupType: v1.OneTimeBackupType,
+		},
+	}
+	backup.SetName(backupName)
+
+	err := mockHandler.validateBackupSpec(backup)
+
+	require.NoError(t, err, "Error when Validating backup spec")
+	require.Equal(t, backup.Spec.RetentionCount, int64(1))
 }
 
 func TestBackupIsSingularAndComplete(t *testing.T) {


### PR DESCRIPTION
https://github.com/rancher/backup-restore-operator/issues/802

BRO sets the status.backupType field only after fully processing a backup. This causes backups to only get a backupType value if they succeed at least once. As this value is important for metrics filtering in the newly created BRO Grafana dashboards, we should move that to be done before the backup can be error out.

This is a second approach to solving the issue.