### PR TITLE
add extra manifest to chart

### DIFF
--- a/charts/rancher-backup/templates/extra-manifests.yaml
+++ b/charts/rancher-backup/templates/extra-manifests.yaml
@@ -1,0 +1,4 @@
+{{ range .Values.extraObjects }}
+---
+{{ tpl (toYaml .) $ }}
+{{ end }}


### PR DESCRIPTION
Adds an extra manifests file to helm chart in order to deploy extra items as part of a helm release.

The file and values have been copied from ranchers own helm chart.