### PR TITLE
feat: Add openreports.io CRDs to Kubewarden resourceset

### DIFF
--- a/charts/rancher-backup/files/optional/basic-resourceset-contents/kubewarden.yaml
+++ b/charts/rancher-backup/files/optional/basic-resourceset-contents/kubewarden.yaml
@@ -40,6 +40,9 @@
 - apiVersion: "apiextensions.k8s.io/v1"
   kindsRegexp: "."
   resourceNameRegexp: "wgpolicyk8s.io$"
+- apiVersion: "apiextensions.k8s.io/v1"
+  kindsRegexp: "."
+  resourceNameRegexp: "openreports.io$"
 
 # kubewarden-controller deployment
 - apiVersion: "apps/v1"


### PR DESCRIPTION
Part of https://github.com/kubewarden/audit-scanner/issues/532, unblocked recently, and which is scheduled to be released in Kubewarden 1.30 at the end of October.

This PR adds the openreports.io CRDs to the Kubewarden resourceset, to be backed up and restored when `.Values.optionalResources.kubewarden.enabled` is `true`.