### PR TITLE
Add v1beta2 CAPI objects

### DIFF
--- a/charts/rancher-backup/files/default/basic-resourceset-contents/provisioningv2.yaml
+++ b/charts/rancher-backup/files/default/basic-resourceset-contents/provisioningv2.yaml
@@ -9,7 +9,7 @@
   kindsRegexp: "."
 - apiVersion: "rke.cattle.io/v1"
   kindsRegexp: "."
-- apiVersion: "cluster.x-k8s.io/v1beta1"
+- apiVersion: "cluster.x-k8s.io/v1beta2"
   kindsRegexp: "."
 - apiVersion: "v1"
   kindsRegexp: "^configmaps$"

--- a/e2e/test/data/rancher-resource-set-basic.yaml
+++ b/e2e/test/data/rancher-resource-set-basic.yaml
@@ -182,7 +182,7 @@ resourceSelectors:
     kindsRegexp: "."
   - apiVersion: "rke.cattle.io/v1"
     kindsRegexp: "."
-  - apiVersion: "cluster.x-k8s.io/v1beta1"
+  - apiVersion: "cluster.x-k8s.io/v1beta2"
     kindsRegexp: "."
   - apiVersion: "v1"
     kindsRegexp: "^configmaps$"

--- a/e2e/test/data/rancher-resource-set-full.yaml
+++ b/e2e/test/data/rancher-resource-set-full.yaml
@@ -182,7 +182,7 @@ resourceSelectors:
     kindsRegexp: "."
   - apiVersion: "rke.cattle.io/v1"
     kindsRegexp: "."
-  - apiVersion: "cluster.x-k8s.io/v1beta1"
+  - apiVersion: "cluster.x-k8s.io/v1beta2"
     kindsRegexp: "."
   - apiVersion: "v1"
     kindsRegexp: "^configmaps$"


### PR DESCRIPTION
The current version of `backup-restore-operator` fails during the restore process on some resources, for example `MachineInventorySelectorTemplate` in Elemental v1.8.2-beta2.

This is because in Rancher v2.14 CAPI has been updated from `v1beta1` to `v1bveta2`. Adding the missing version fix the restore on my lab.

With v9.0.1 I had this kind of warning that I don't have anymore:
```
I0226 14:31:34.600740       1 warnings.go:110] "Warning: cluster.x-k8s.io/v1beta1 Cluster is deprecated; use cluster.x-k8s.io/v1beta2 Cluster"
I0226 14:31:37.192375       1 warnings.go:110] "Warning: cluster.x-k8s.io/v1beta1 MachinePool is deprecated; use cluster.x-k8s.io/v1beta2 MachinePool"
I0226 14:31:37.195326       1 warnings.go:110] "Warning: cluster.x-k8s.io/v1beta1 MachineDeployment is deprecated; use cluster.x-k8s.io/v1beta2 MachineDeployment"
```

For Elemental restore I had no specific error but with this fix I have more logs confirming the restore of some resources, like this:
```
INFO[2026/02/26 18:30:30] restoreResource: Restoring cluster-master-worker-master-d5p5n-5s77k of type elemental.cattle.io/v1beta1, Resource=machineinventoryselectors 
INFO[2026/02/26 18:30:30] restoreResource: Namespace fleet-default for name cluster-master-worker-master-d5p5n-5s77k of type elemental.cattle.io/v1beta1, Resource=machineinventoryselectors 
INFO[2026/02/26 18:30:30] Updating status subresource for "cluster-master-worker-master-d5p5n-5s77k" of type elemental.cattle.io/v1beta1, Resource=machineinventoryselectors
```

**NOTE:** I tried to keep `v1beta1` as I don't know if it is needed for compatibility reason but it doesn't work, I have to replace it with `v1beta2`.