### PR TITLE
[v2.13] Revert "Add v1beta2 CAPI objects (#875)"

### DIFF
--- a/charts/rancher-backup/files/default/basic-resourceset-contents/provisioningv2.yaml
+++ b/charts/rancher-backup/files/default/basic-resourceset-contents/provisioningv2.yaml
@@ -9,7 +9,7 @@
   kindsRegexp: "."
 - apiVersion: "rke.cattle.io/v1"
   kindsRegexp: "."
-- apiVersion: "cluster.x-k8s.io/v1beta2"
+- apiVersion: "cluster.x-k8s.io/v1beta1"
   kindsRegexp: "."
 - apiVersion: "v1"
   kindsRegexp: "^configmaps$"

--- a/e2e/test/data/rancher-resource-set-basic.yaml
+++ b/e2e/test/data/rancher-resource-set-basic.yaml
@@ -182,7 +182,7 @@ resourceSelectors:
     kindsRegexp: "."
   - apiVersion: "rke.cattle.io/v1"
     kindsRegexp: "."
-  - apiVersion: "cluster.x-k8s.io/v1beta2"
+  - apiVersion: "cluster.x-k8s.io/v1beta1"
     kindsRegexp: "."
   - apiVersion: "v1"
     kindsRegexp: "^configmaps$"

--- a/e2e/test/data/rancher-resource-set-full.yaml
+++ b/e2e/test/data/rancher-resource-set-full.yaml
@@ -182,7 +182,7 @@ resourceSelectors:
     kindsRegexp: "."
   - apiVersion: "rke.cattle.io/v1"
     kindsRegexp: "."
-  - apiVersion: "cluster.x-k8s.io/v1beta2"
+  - apiVersion: "cluster.x-k8s.io/v1beta1"
     kindsRegexp: "."
   - apiVersion: "v1"
     kindsRegexp: "^configmaps$"


### PR DESCRIPTION
This reverts commit ee05c54c0224586c25ed27b06e8e0d2c82948fd4.

---

On 2.13 branch we still need only v1beta1 as far as I know. (verifying)