### PR TITLE
Add GitHub Actions workflow to automate updates of rancher-backup charts

### DIFF
--- a/.github/workflows/push-to-charts.yaml
+++ b/.github/workflows/push-to-charts.yaml
@@ -1,0 +1,53 @@
+name: Push to rancher/charts
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to process (e.g. v9.0.2-rc.5)'
+        required: true
+        type: string
+
+jobs:
+  push-to-charts:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install yq and gh
+        run: |
+          ARCH=$(uname -m)
+          if [ "$ARCH" = "x86_64" ]; then SYSTEM_ARCH="amd64"; elif [ "$ARCH" = "aarch64" ]; then SYSTEM_ARCH="arm64"; else echo "Unsupported architecture: $ARCH"; exit 1; fi
+          curl -L "https://github.com/mikefarah/yq/releases/latest/download/yq_linux_${SYSTEM_ARCH}" -o /usr/local/bin/yq && chmod +x /usr/local/bin/yq
+          curl -L "https://github.com/cli/cli/releases/download/v2.82.0/gh_2.82.0_linux_${SYSTEM_ARCH}.tar.gz" -o gh.tar.gz && tar -zxvf gh.tar.gz && mv "gh_2.82.0_linux_${SYSTEM_ARCH}/bin/gh" /usr/local/bin/gh && rm -rf gh.tar.gz "gh_2.82.0_linux_${SYSTEM_ARCH}"
+
+      - name: Read App Credentials from Vault
+        uses: rancher-eio/read-vault-secrets@main
+        with:
+          secrets: |
+            secret/data/github/repo/${{ github.repository }}/github/app-credentials appId | APPID;
+            secret/data/github/repo/${{ github.repository }}/github/app-credentials privateKey | PRIVATEKEY
+
+      - name: Generate GitHub App Token
+        id: generate_token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ env.APPID }}
+          private-key: ${{ env.PRIVATEKEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: charts
+
+      - name: Push chart update to rancher/charts
+        env:
+          TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
+          SOURCE_REPO: ${{ github.repository }}
+          BRO_DIR: ${{ github.workspace }}
+          CHARTS_DIR: ${{ github.workspace }}/charts-repo
+        run: ./.github/workflows/push-to-charts/run-gha.sh

--- a/.github/workflows/push-to-charts/README.md
+++ b/.github/workflows/push-to-charts/README.md
@@ -1,0 +1,68 @@
+# push-to-charts
+
+Automates opening PRs against [rancher/charts](https://github.com/rancher/charts) when a new BRO release is published.
+
+## Trigger
+
+The workflow fires on `release: published` (after goreleaser uploads chart artifacts) and can also be dispatched manually with an explicit tag.
+
+Because `release: published` always runs from the default branch, **no backporting is needed** — a single copy of these scripts handles all version lines via `CHARTS_BRANCH_MAP` in `common.sh`.
+
+## Adding a new BRO/Rancher version pair
+
+Edit `common.sh` and add an entry to `CHARTS_BRANCH_MAP`:
+
+```bash
+["10"]="dev-v2.14"
+```
+
+## Local usage
+
+```bash
+./.github/workflows/push-to-charts/run-local.sh \
+  --charts-dir /path/to/rancher/charts \
+  --tag v9.0.2-rc.5 \
+  [--dry-run] \
+  [--remote upstream]
+```
+
+`--dry-run` runs all local git work (commits to your charts clone) but skips push and PR creation.
+
+## Step sequence
+
+| Script | What it does |
+|---|---|
+| `remove-previous-rc.sh` | `make remove` for the previous RC charts version. No-op if base BRO version changed or old version was not a prerelease. |
+| `update-package-yaml.sh` | Updates `url` and `additionalCharts[0].upstreamOptions.url` to the new release artifacts. Bumps charts version (minor or patch) unless the base BRO version is unchanged (RC→RC or RC→stable). |
+| `update-patches.sh` | Updates `appVersion` in `Chart.yaml.patch`, then runs `make prepare`, `make patch`, `make clean`. |
+| `generate-assets.sh` | Runs `make charts USE_CACHE=true`. |
+| `create-pr.sh` | Pushes the branch and opens a PR against the target branch in rancher/charts. |
+
+## Version bump rules
+
+| Transition | Charts version |
+|---|---|
+| `9.0.1` → `9.0.2-rc.1` | patch bump: `108.0.1` → `108.0.2` |
+| `9.0.2-rc.1` → `9.0.2-rc.5` | no bump: stays `108.0.2` |
+| `9.0.2-rc.5` → `9.0.2` | no bump: stays `108.0.2` |
+| `9.0.2` → `9.1.0-rc.1` | minor bump: `108.0.2` → `108.1.0` |
+
+## Key env vars
+
+| Var | Description |
+|---|---|
+| `TAG` | BRO release tag (e.g. `v9.0.2-rc.5`) |
+| `CHARTS_DIR` | Path to local rancher/charts clone |
+| `CHARTS_REMOTE` | Remote name in `CHARTS_DIR` (default: `origin`) |
+| `DRY_RUN` | Set to `true` to skip push and PR creation |
+| `SOURCE_REPO` | Source repo for PR body (default: `rancher/backup-restore-operator`) |
+
+## GHA prerequisites
+
+The workflow reads a GitHub App credential from Vault at:
+
+```
+secret/data/github/repo/rancher/backup-restore-operator/github/app-credentials
+```
+
+The app must have write access to `rancher/charts` to push branches and open PRs.

--- a/.github/workflows/push-to-charts/README.md
+++ b/.github/workflows/push-to-charts/README.md
@@ -47,6 +47,7 @@ Edit `common.sh` and add an entry to `CHARTS_BRANCH_MAP`:
 | `9.0.2-rc.1` → `9.0.2-rc.5` | no bump: stays `108.0.2` |
 | `9.0.2-rc.5` → `9.0.2` | no bump: stays `108.0.2` |
 | `9.0.2` → `9.1.0-rc.1` | minor bump: `108.0.2` → `108.1.0` |
+| `9.x.x` → `10.0.0-rc.1` | major bump: `108.x.x` → `109.0.0` |
 
 ## Key env vars
 

--- a/.github/workflows/push-to-charts/README.md
+++ b/.github/workflows/push-to-charts/README.md
@@ -36,6 +36,7 @@ Edit `common.sh` and add an entry to `CHARTS_BRANCH_MAP`:
 | `update-package-yaml.sh` | Updates `url` and `additionalCharts[0].upstreamOptions.url` to the new release artifacts. Bumps charts version (minor or patch) unless the base BRO version is unchanged (RC→RC or RC→stable). |
 | `update-patches.sh` | Updates `appVersion` in `Chart.yaml.patch`, then runs `make prepare`, `make patch`, `make clean`. |
 | `generate-assets.sh` | Runs `make charts USE_CACHE=true`. |
+| `update-release-yaml.sh` | Prepends the new combined version (`{charts_version}+up{bro_version}`) to `rancher-backup` and `rancher-backup-crd` entries in `release.yaml`. |
 | `create-pr.sh` | Pushes the branch and opens a PR against the target branch in rancher/charts. |
 
 ## Version bump rules

--- a/.github/workflows/push-to-charts/common.sh
+++ b/.github/workflows/push-to-charts/common.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Shared setup for push-to-charts scripts. Source this file: source "$(dirname "$0")/common.sh"
+
+# Determine BRO_DIR (backup-restore-operator root) from this script's location
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BRO_DIR="${BRO_DIR:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+
+# Required: path to a local rancher/charts clone
+CHARTS_DIR="${CHARTS_DIR:-}"
+
+# Remote name for rancher/charts in CHARTS_DIR (may differ locally if using a fork)
+CHARTS_REMOTE="${CHARTS_REMOTE:-origin}"
+
+# Skip git commits, push, and PR creation when true
+DRY_RUN="${DRY_RUN:-false}"
+
+# Static package name for backup-restore-operator in rancher/charts
+PACKAGE="rancher-backup"
+
+# Map of BRO major version → rancher/charts target branch.
+# Add a new entry here when a new BRO/Rancher version pair is created.
+declare -A CHARTS_BRANCH_MAP=(
+  ["10"]="dev-v2.14"
+  ["9"]="dev-v2.13"
+  ["8"]="dev-v2.12"
+  ["7"]="dev-v2.11"
+  ["6"]="dev-v2.10"
+  ["5"]="dev-v2.9"
+)
+
+# Resolve the rancher/charts target branch for a given BRO tag (e.g. v9.0.2-rc.5).
+# Prints the branch name and exits 1 if the major version is not in the map.
+get_charts_branch() {
+  local tag="${1#v}"  # strip leading v
+  local major
+  major=$(echo "$tag" | cut -d. -f1)
+  local branch="${CHARTS_BRANCH_MAP[$major]:-}"
+  if [ -z "$branch" ]; then
+    echo "ERROR: No rancher/charts branch configured for BRO major version '$major' (tag: $1)" >&2
+    echo "ERROR: Add an entry to CHARTS_BRANCH_MAP in common.sh" >&2
+    exit 1
+  fi
+  echo "$branch"
+}
+
+# Write to GitHub step summary if available, and always print to stdout
+summary() {
+  if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+    echo "$@" >> "$GITHUB_STEP_SUMMARY"
+  fi
+  echo "$@"
+}
+
+require_var() {
+  local var="$1"
+  if [ -z "${!var:-}" ]; then
+    echo "ERROR: $var is required" >&2
+    exit 1
+  fi
+}
+
+require_charts_dir() {
+  require_var CHARTS_DIR
+  if [ ! -d "$CHARTS_DIR" ]; then
+    echo "ERROR: CHARTS_DIR '$CHARTS_DIR' does not exist" >&2
+    exit 1
+  fi
+}
+
+# Commit all changes in CHARTS_DIR if any exist. Does nothing if tree is clean.
+commit_if_changed() {
+  local message="$1"
+  if git -C "$CHARTS_DIR" diff --quiet --exit-code && [ -z "$(git -C "$CHARTS_DIR" status --porcelain)" ]; then
+    return 0
+  fi
+  git -C "$CHARTS_DIR" add .
+  git -C "$CHARTS_DIR" commit -m "$message"
+}

--- a/.github/workflows/push-to-charts/common.sh
+++ b/.github/workflows/push-to-charts/common.sh
@@ -67,6 +67,21 @@ require_charts_dir() {
   fi
 }
 
+# Returns 0 if the given TARGET_BRANCH is frozen, 1 otherwise.
+is_branch_frozen() {
+  local target_branch="$1"
+  local freeze_manifest="${2:-/tmp/bro-push/code-freeze.yaml}"
+  if [ ! -f "$freeze_manifest" ]; then
+    return 1
+  fi
+  local manifest_branch_name
+  manifest_branch_name=$(echo "$target_branch" | sed 's|dev-v|release/v|')
+  local manifest_ref="refs/heads/$manifest_branch_name"
+  local result
+  result=$(yq e ".spec.forProvider.conditions[].refName[].include[] | select(. == \"$manifest_ref\")" "$freeze_manifest")
+  [ -n "$result" ]
+}
+
 # Commit all changes in CHARTS_DIR if any exist. Does nothing if tree is clean.
 commit_if_changed() {
   local message="$1"

--- a/.github/workflows/push-to-charts/create-pr.sh
+++ b/.github/workflows/push-to-charts/create-pr.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Push the working branch to rancher/charts and open a PR.
+#
+# Inputs (env):
+#   CHARTS_DIR     - path to rancher/charts clone (required)
+#   TARGET_BRANCH  - base branch for the PR (required)
+#   BRANCH_NAME    - working branch to push (required)
+#   TAG            - BRO release tag, used in PR title (required)
+#   SOURCE_REPO    - source repo for PR body (default: rancher/backup-restore-operator)
+#   DRY_RUN        - skip push and PR creation if "true"
+set -euo pipefail
+source "$(dirname "$0")/common.sh"
+
+require_charts_dir
+require_var TARGET_BRANCH
+require_var BRANCH_NAME
+require_var TAG
+
+SOURCE_REPO="${SOURCE_REPO:-rancher/backup-restore-operator}"
+
+PR_TITLE="chore(charts): Update rancher-backup to ${TAG} for ${TARGET_BRANCH}"
+PR_BODY="Automated PR to update \`rancher-backup\` and \`rancher-backup-crd\` charts from [${SOURCE_REPO}](https://github.com/${SOURCE_REPO}/releases/tag/${TAG}) release \`${TAG}\`."
+
+if [ "$DRY_RUN" = "true" ]; then
+  echo "[DRY RUN] Skipping push and PR creation."
+  echo "  Branch: $BRANCH_NAME"
+  echo "  Title:  $PR_TITLE"
+  echo "  Base:   $TARGET_BRANCH"
+  echo "All commits are in your local $CHARTS_DIR checkout."
+  exit 0
+fi
+
+git -C "$CHARTS_DIR" push "$CHARTS_REMOTE" "$BRANCH_NAME"
+PR_URL=$(gh pr create \
+  --title "$PR_TITLE" \
+  --body "$PR_BODY" \
+  --base "$TARGET_BRANCH" \
+  --head "$BRANCH_NAME" \
+  --repo rancher/charts)
+
+summary "  - Created PR: $PR_URL"
+echo "$PR_URL"

--- a/.github/workflows/push-to-charts/create-pr.sh
+++ b/.github/workflows/push-to-charts/create-pr.sh
@@ -18,7 +18,19 @@ require_var TAG
 
 SOURCE_REPO="${SOURCE_REPO:-rancher/backup-restore-operator}"
 
-PR_TITLE="chore(charts): Update rancher-backup to ${TAG} for ${TARGET_BRANCH}"
+# Build the combined version string: {charts_version}+up{bro_version_without_v}
+TAG_NO_V="${TAG#v}"
+CHARTS_VERSION=$(yq e '.version' "$CHARTS_DIR/packages/$PACKAGE/package.yaml")
+COMBINED_VERSION="${CHARTS_VERSION}+up${TAG_NO_V}"
+
+# Determine action: prerelease tags are a "bump", stable tags are an "UnRC"
+if [[ "$TAG_NO_V" == *"-"* ]]; then
+  ACTION="bump"
+else
+  ACTION="UnRC"
+fi
+
+PR_TITLE="[${TARGET_BRANCH}] rancher-backup ${COMBINED_VERSION} ${ACTION}"
 PR_BODY="Automated PR to update \`rancher-backup\` and \`rancher-backup-crd\` charts from [${SOURCE_REPO}](https://github.com/${SOURCE_REPO}/releases/tag/${TAG}) release \`${TAG}\`."
 
 if [ "$DRY_RUN" = "true" ]; then
@@ -26,6 +38,7 @@ if [ "$DRY_RUN" = "true" ]; then
   echo "  Branch: $BRANCH_NAME"
   echo "  Title:  $PR_TITLE"
   echo "  Base:   $TARGET_BRANCH"
+  echo "  Version: $COMBINED_VERSION"
   echo "All commits are in your local $CHARTS_DIR checkout."
   exit 0
 fi

--- a/.github/workflows/push-to-charts/generate-assets.sh
+++ b/.github/workflows/push-to-charts/generate-assets.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Generate chart assets from the updated package.yaml and patches.
+#
+# Prerequisites: update-patches.sh
+#
+# Inputs (env):
+#   CHARTS_DIR - path to rancher/charts clone (required)
+#   PACKAGE    - package name (set by common.sh: "rancher-backup")
+set -euo pipefail
+source "$(dirname "$0")/common.sh"
+
+require_charts_dir
+
+make -C "$CHARTS_DIR" charts PACKAGE="$PACKAGE" USE_CACHE=true
+
+commit_if_changed "chore(charts): Generate rancher-backup chart assets"
+summary "  - Chart assets generated"

--- a/.github/workflows/push-to-charts/remove-previous-rc.sh
+++ b/.github/workflows/push-to-charts/remove-previous-rc.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Remove the previous RC charts version when publishing a new RC or stable for the same base version.
+# Skipped automatically if the old BRO base version differs from the new one (no RC to clean up).
+#
+# Prerequisites: none (runs before update-package-yaml.sh)
+#
+# Inputs (env):
+#   TAG        - new BRO release tag (e.g. v9.0.2-rc.5 or v9.0.2) (required)
+#   CHARTS_DIR - path to rancher/charts clone (required)
+#   PACKAGE    - package name (set by common.sh: "rancher-backup")
+#
+# Output: git commit in CHARTS_DIR (only if removal was performed)
+set -euo pipefail
+source "$(dirname "$0")/common.sh"
+
+require_var TAG
+require_charts_dir
+
+PACKAGE_YAML="$CHARTS_DIR/packages/$PACKAGE/package.yaml"
+
+# Extract old BRO version from current URL and strip any prerelease suffix
+CURRENT_URL=$(yq e '.url' "$PACKAGE_YAML")
+OLD_BRO_VERSION=$(echo "$CURRENT_URL" | sed 's|.*/rancher-backup-||' | sed 's|\.tgz$||')
+OLD_BRO_BASE=$(echo "$OLD_BRO_VERSION" | sed 's/-.*//')
+
+# New BRO base version (strip prerelease)
+TAG_NO_V="${TAG#v}"
+NEW_BRO_BASE=$(echo "$TAG_NO_V" | sed 's/-.*//')
+
+# Only remove if the base version is unchanged AND the old version was a prerelease
+if [ "$OLD_BRO_BASE" != "$NEW_BRO_BASE" ]; then
+  summary "  - Base version changed ($OLD_BRO_BASE → $NEW_BRO_BASE), no RC to remove"
+  exit 0
+fi
+
+if [[ "$OLD_BRO_VERSION" != *"-"* ]]; then
+  summary "  - Old version $OLD_BRO_VERSION is not a prerelease, nothing to remove"
+  exit 0
+fi
+
+PREV_CHARTS_VERSION=$(yq e '.version' "$PACKAGE_YAML")
+summary "  - Removing previous RC: $PACKAGE $PREV_CHARTS_VERSION"
+
+make -C "$CHARTS_DIR" remove CHART="$PACKAGE" VERSION="$PREV_CHARTS_VERSION"
+make -C "$CHARTS_DIR" remove CHART="${PACKAGE}-crd" VERSION="$PREV_CHARTS_VERSION"
+
+commit_if_changed "chore(charts): Remove previous RC rancher-backup $PREV_CHARTS_VERSION"

--- a/.github/workflows/push-to-charts/remove-previous-rc.sh
+++ b/.github/workflows/push-to-charts/remove-previous-rc.sh
@@ -38,10 +38,16 @@ if [[ "$OLD_BRO_VERSION" != *"-"* ]]; then
   exit 0
 fi
 
-PREV_CHARTS_VERSION=$(yq e '.version' "$PACKAGE_YAML")
+PREV_CHARTS_BASE_VERSION=$(yq e '.version' "$PACKAGE_YAML")
+PREV_CHARTS_VERSION="${PREV_CHARTS_BASE_VERSION}+up${OLD_BRO_VERSION}"
 summary "  - Removing previous RC: $PACKAGE $PREV_CHARTS_VERSION"
 
-make -C "$CHARTS_DIR" remove CHART="$PACKAGE" VERSION="$PREV_CHARTS_VERSION"
-make -C "$CHARTS_DIR" remove CHART="${PACKAGE}-crd" VERSION="$PREV_CHARTS_VERSION"
+make -C "$CHARTS_DIR" remove CHART="$PACKAGE" VERSION="$PREV_CHARTS_VERSION" || true
+make -C "$CHARTS_DIR" remove CHART="${PACKAGE}-crd" VERSION="$PREV_CHARTS_VERSION" || true
+
+# Also remove from release.yaml (make remove does not touch it)
+RELEASE_YAML="$CHARTS_DIR/release.yaml"
+yq e -i ".${PACKAGE} |= map(select(. != \"${PREV_CHARTS_VERSION}\"))" "$RELEASE_YAML"
+yq e -i ".${PACKAGE}-crd |= map(select(. != \"${PREV_CHARTS_VERSION}\"))" "$RELEASE_YAML"
 
 commit_if_changed "chore(charts): Remove previous RC rancher-backup $PREV_CHARTS_VERSION"

--- a/.github/workflows/push-to-charts/run-gha.sh
+++ b/.github/workflows/push-to-charts/run-gha.sh
@@ -51,6 +51,9 @@ bash "$SCRIPT_DIR/update-patches.sh"
 summary "- Generating chart assets..."
 bash "$SCRIPT_DIR/generate-assets.sh"
 
+summary "- Updating release.yaml..."
+bash "$SCRIPT_DIR/update-release-yaml.sh"
+
 summary "- Pushing changes and creating PR..."
 export SOURCE_REPO="${SOURCE_REPO:-rancher/backup-restore-operator}"
 bash "$SCRIPT_DIR/create-pr.sh"

--- a/.github/workflows/push-to-charts/run-gha.sh
+++ b/.github/workflows/push-to-charts/run-gha.sh
@@ -25,6 +25,19 @@ summary "## Push to rancher/charts"
 summary "- Tag: \`$TAG\`"
 summary "- Target branch: \`$TARGET_BRANCH\`"
 
+# --- Check code freeze ---
+FREEZE_MANIFEST="/tmp/bro-push/code-freeze.yaml"
+mkdir -p "$(dirname "$FREEZE_MANIFEST")"
+curl -sf -H "Authorization: token $GH_TOKEN" \
+  "https://raw.githubusercontent.com/rancher/org/refs/heads/main/manifests/resources/RepositoryRuleset/rancher/code-freeze.yaml" \
+  -o "$FREEZE_MANIFEST" || echo "WARNING: Could not fetch code-freeze manifest, freeze check skipped" >&2
+
+if is_branch_frozen "$TARGET_BRANCH" "$FREEZE_MANIFEST"; then
+  MANIFEST_BRANCH=$(echo "$TARGET_BRANCH" | sed 's|dev-v|release/v|')
+  summary "- Branch \`$MANIFEST_BRANCH\` is currently frozen. Skipping."
+  exit 0
+fi
+
 # --- Clone downstream repo ---
 git clone "https://oauth2:${GH_TOKEN}@github.com/rancher/charts.git" "$CHARTS_DIR"
 git -C "$CHARTS_DIR" config user.name "github-actions[bot]"

--- a/.github/workflows/push-to-charts/run-gha.sh
+++ b/.github/workflows/push-to-charts/run-gha.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# GHA entry point: orchestrates the full chart update workflow.
+# Called from push-to-charts.yaml after token generation.
+#
+# Required env vars (set by push-to-charts.yaml):
+#   TAG         - BRO release tag (e.g. v9.0.2-rc.5)
+#   GH_TOKEN    - GitHub app token with access to rancher/charts
+#   SOURCE_REPO - source repo (github.repository)
+#   BRO_DIR     - path to backup-restore-operator workspace ($GITHUB_WORKSPACE)
+#   CHARTS_DIR  - path to clone rancher/charts into
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+require_var TAG
+require_var GH_TOKEN
+
+export BRO_DIR CHARTS_DIR DRY_RUN
+
+TARGET_BRANCH=$(get_charts_branch "$TAG")
+export TARGET_BRANCH
+
+summary "## Push to rancher/charts"
+summary "- Tag: \`$TAG\`"
+summary "- Target branch: \`$TARGET_BRANCH\`"
+
+# --- Clone downstream repo ---
+git clone "https://oauth2:${GH_TOKEN}@github.com/rancher/charts.git" "$CHARTS_DIR"
+git -C "$CHARTS_DIR" config user.name "github-actions[bot]"
+git -C "$CHARTS_DIR" config user.email "github-actions[bot]@users.noreply.github.com"
+
+git -C "$CHARTS_DIR" checkout -B "$TARGET_BRANCH" "$CHARTS_REMOTE/$TARGET_BRANCH"
+
+BRANCH_NAME="bot/bro-${TAG}-$(date +%s)"
+git -C "$CHARTS_DIR" checkout -b "$BRANCH_NAME"
+export BRANCH_NAME
+
+summary ""
+summary "## Steps"
+
+summary "- Removing previous RC (if applicable)..."
+bash "$SCRIPT_DIR/remove-previous-rc.sh"
+
+summary "- Updating package.yaml..."
+bash "$SCRIPT_DIR/update-package-yaml.sh"
+
+summary "- Updating chart patches..."
+bash "$SCRIPT_DIR/update-patches.sh"
+
+summary "- Generating chart assets..."
+bash "$SCRIPT_DIR/generate-assets.sh"
+
+summary "- Pushing changes and creating PR..."
+export SOURCE_REPO="${SOURCE_REPO:-rancher/backup-restore-operator}"
+bash "$SCRIPT_DIR/create-pr.sh"
+
+summary ""
+summary "## Workflow Complete"

--- a/.github/workflows/push-to-charts/run-local.sh
+++ b/.github/workflows/push-to-charts/run-local.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Local entry point for running the chart update workflow against a local charts clone.
+#
+# Usage:
+#   ./run-local.sh --charts-dir /path/to/rancher/charts --tag v9.0.2-rc.5 [OPTIONS]
+#
+# Options:
+#   --charts-dir DIR    Path to local rancher/charts clone (required)
+#   --tag TAG           BRO release tag to process (e.g. v9.0.2-rc.5) (required)
+#   --remote NAME       Remote name for rancher/charts in CHARTS_DIR (default: origin)
+#   --source-repo REPO  Source repo for PR body (default: rancher/backup-restore-operator)
+#   --dry-run           Skip push and PR creation (all local git work still runs)
+#   --help              Show this message
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+usage() {
+  sed -n '/^# Usage/,/^[^#]/{ s/^# \{0,1\}//; /^[^#]/d; p }' "$0"
+  exit 0
+}
+
+TAG=""
+SOURCE_REPO="rancher/backup-restore-operator"
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --charts-dir)  CHARTS_DIR="$2";    shift 2 ;;
+    --tag)         TAG="$2";           shift 2 ;;
+    --remote)      CHARTS_REMOTE="$2"; shift 2 ;;
+    --source-repo) SOURCE_REPO="$2";   shift 2 ;;
+    --dry-run)     DRY_RUN="true";     shift ;;
+    --help|-h)     usage ;;
+    *) echo "Unknown option: $1" >&2; usage ;;
+  esac
+done
+
+require_var TAG
+require_charts_dir
+
+TARGET_BRANCH=$(get_charts_branch "$TAG")
+export TAG TARGET_BRANCH CHARTS_DIR CHARTS_REMOTE DRY_RUN BRO_DIR SOURCE_REPO
+
+echo "Tag:           $TAG"
+echo "Target branch: $TARGET_BRANCH"
+echo "Charts dir:    $CHARTS_DIR"
+echo "Dry run:       $DRY_RUN"
+echo ""
+
+git -C "$CHARTS_DIR" checkout -B "$TARGET_BRANCH" "$CHARTS_REMOTE/$TARGET_BRANCH"
+
+BRANCH_NAME="bot/bro-${TAG}-$(date +%s)"
+git -C "$CHARTS_DIR" checkout -b "$BRANCH_NAME"
+export BRANCH_NAME
+
+echo "--- Removing previous RC (if applicable) ---"
+bash "$SCRIPT_DIR/remove-previous-rc.sh"
+
+echo "--- Updating package.yaml ---"
+bash "$SCRIPT_DIR/update-package-yaml.sh"
+
+echo "--- Updating chart patches ---"
+bash "$SCRIPT_DIR/update-patches.sh"
+
+echo "--- Generating chart assets ---"
+bash "$SCRIPT_DIR/generate-assets.sh"
+
+echo "--- Creating PR ---"
+bash "$SCRIPT_DIR/create-pr.sh"
+
+echo ""
+echo "Workflow complete."

--- a/.github/workflows/push-to-charts/run-local.sh
+++ b/.github/workflows/push-to-charts/run-local.sh
@@ -66,6 +66,9 @@ bash "$SCRIPT_DIR/update-patches.sh"
 echo "--- Generating chart assets ---"
 bash "$SCRIPT_DIR/generate-assets.sh"
 
+echo "--- Updating release.yaml ---"
+bash "$SCRIPT_DIR/update-release-yaml.sh"
+
 echo "--- Creating PR ---"
 bash "$SCRIPT_DIR/create-pr.sh"
 

--- a/.github/workflows/push-to-charts/run-local.sh
+++ b/.github/workflows/push-to-charts/run-local.sh
@@ -48,6 +48,7 @@ echo "Charts dir:    $CHARTS_DIR"
 echo "Dry run:       $DRY_RUN"
 echo ""
 
+git -C "$CHARTS_DIR" fetch "$CHARTS_REMOTE"
 git -C "$CHARTS_DIR" checkout -B "$TARGET_BRANCH" "$CHARTS_REMOTE/$TARGET_BRANCH"
 
 BRANCH_NAME="bot/bro-${TAG}-$(date +%s)"

--- a/.github/workflows/push-to-charts/update-package-yaml.sh
+++ b/.github/workflows/push-to-charts/update-package-yaml.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Update packages/rancher-backup/package.yaml in rancher/charts for a new BRO release.
+#
+# Inputs (env):
+#   TAG         - BRO release tag (e.g. v9.0.2-rc.5) (required)
+#   CHARTS_DIR  - path to rancher/charts clone (required)
+#   PACKAGE     - package name (set by common.sh: "rancher-backup")
+#
+# Updates:
+#   url                              → new chart tarball URL for TAG
+#   additionalCharts[0].upstreamOptions.url → new CRD chart tarball URL for TAG
+#   version                          → auto-incremented (minor bump if BRO minor changed, else patch)
+#
+# Output: git commit in CHARTS_DIR
+set -euo pipefail
+source "$(dirname "$0")/common.sh"
+
+require_var TAG
+require_charts_dir
+
+BRO_REPO_URL="https://github.com/rancher/backup-restore-operator"
+TAG_NO_V="${TAG#v}"  # e.g. 9.0.2-rc.5
+
+PACKAGE_YAML="$CHARTS_DIR/packages/$PACKAGE/package.yaml"
+if [ ! -f "$PACKAGE_YAML" ]; then
+  echo "ERROR: package.yaml not found at $PACKAGE_YAML" >&2
+  exit 1
+fi
+
+# --- Compute new URLs ---
+NEW_URL="${BRO_REPO_URL}/releases/download/${TAG}/rancher-backup-${TAG_NO_V}.tgz"
+NEW_CRD_URL="${BRO_REPO_URL}/releases/download/${TAG}/rancher-backup-crd-${TAG_NO_V}.tgz"
+
+# --- Compute new charts version ---
+# Read old BRO version from the current URL and strip any prerelease suffix
+CURRENT_URL=$(yq e '.url' "$PACKAGE_YAML")
+OLD_BRO_VERSION=$(echo "$CURRENT_URL" | sed 's|.*/rancher-backup-||' | sed 's|\.tgz$||')
+OLD_BRO_BASE=$(echo "$OLD_BRO_VERSION" | sed 's/-.*//')
+
+# New BRO base version (strip prerelease)
+NEW_BRO_BASE=$(echo "$TAG_NO_V" | sed 's/-.*//')
+
+CURRENT_CHARTS_VERSION=$(yq e '.version' "$PACKAGE_YAML")
+CHARTS_MAJOR=$(echo "$CURRENT_CHARTS_VERSION" | cut -d. -f1)
+CHARTS_MINOR=$(echo "$CURRENT_CHARTS_VERSION" | cut -d. -f2)
+CHARTS_PATCH=$(echo "$CURRENT_CHARTS_VERSION" | cut -d. -f3)
+
+if [ "$OLD_BRO_BASE" = "$NEW_BRO_BASE" ]; then
+  # Same base BRO version (RC→RC or RC→stable): version was already bumped, keep it
+  NEW_CHARTS_VERSION="$CURRENT_CHARTS_VERSION"
+elif [ "$(echo "$NEW_BRO_BASE" | cut -d. -f2)" != "$(echo "$OLD_BRO_BASE" | cut -d. -f2)" ]; then
+  # BRO minor version changed
+  NEW_CHARTS_VERSION="${CHARTS_MAJOR}.$((CHARTS_MINOR + 1)).0"
+else
+  # BRO patch version changed
+  NEW_CHARTS_VERSION="${CHARTS_MAJOR}.${CHARTS_MINOR}.$((CHARTS_PATCH + 1))"
+fi
+
+# --- Apply updates ---
+yq e -i ".url = \"$NEW_URL\"" "$PACKAGE_YAML"
+yq e -i ".additionalCharts[0].upstreamOptions.url = \"$NEW_CRD_URL\"" "$PACKAGE_YAML"
+yq e -i ".version = \"$NEW_CHARTS_VERSION\"" "$PACKAGE_YAML"
+
+
+summary "  - BRO: \`$OLD_BRO_VERSION\` → \`$TAG_NO_V\`"
+summary "  - Charts version: \`$CURRENT_CHARTS_VERSION\` → \`$NEW_CHARTS_VERSION\`"
+
+commit_if_changed "chore(charts): Update rancher-backup package.yaml for $TAG"

--- a/.github/workflows/push-to-charts/update-package-yaml.sh
+++ b/.github/workflows/push-to-charts/update-package-yaml.sh
@@ -9,7 +9,7 @@
 # Updates:
 #   url                              → new chart tarball URL for TAG
 #   additionalCharts[0].upstreamOptions.url → new CRD chart tarball URL for TAG
-#   version                          → auto-incremented (minor bump if BRO minor changed, else patch)
+#   version                          → auto-incremented: major if BRO major changed, minor if BRO minor changed, else patch
 #
 # Output: git commit in CHARTS_DIR
 set -euo pipefail
@@ -45,10 +45,18 @@ CHARTS_MAJOR=$(echo "$CURRENT_CHARTS_VERSION" | cut -d. -f1)
 CHARTS_MINOR=$(echo "$CURRENT_CHARTS_VERSION" | cut -d. -f2)
 CHARTS_PATCH=$(echo "$CURRENT_CHARTS_VERSION" | cut -d. -f3)
 
+OLD_BRO_MAJOR=$(echo "$OLD_BRO_BASE" | cut -d. -f1)
+NEW_BRO_MAJOR=$(echo "$NEW_BRO_BASE" | cut -d. -f1)
+OLD_BRO_MINOR=$(echo "$OLD_BRO_BASE" | cut -d. -f2)
+NEW_BRO_MINOR=$(echo "$NEW_BRO_BASE" | cut -d. -f2)
+
 if [ "$OLD_BRO_BASE" = "$NEW_BRO_BASE" ]; then
   # Same base BRO version (RC→RC or RC→stable): version was already bumped, keep it
   NEW_CHARTS_VERSION="$CURRENT_CHARTS_VERSION"
-elif [ "$(echo "$NEW_BRO_BASE" | cut -d. -f2)" != "$(echo "$OLD_BRO_BASE" | cut -d. -f2)" ]; then
+elif [ "$NEW_BRO_MAJOR" != "$OLD_BRO_MAJOR" ]; then
+  # BRO major version changed (new Rancher version line seeded from previous branch)
+  NEW_CHARTS_VERSION="$((CHARTS_MAJOR + 1)).0.0"
+elif [ "$NEW_BRO_MINOR" != "$OLD_BRO_MINOR" ]; then
   # BRO minor version changed
   NEW_CHARTS_VERSION="${CHARTS_MAJOR}.$((CHARTS_MINOR + 1)).0"
 else

--- a/.github/workflows/push-to-charts/update-patches.sh
+++ b/.github/workflows/push-to-charts/update-patches.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Regenerate chart patches after updating package.yaml.
+#
+# Prerequisites: update-package-yaml.sh
+#
+# Inputs (env):
+#   CHARTS_DIR - path to rancher/charts clone (required)
+#   PACKAGE    - package name (set by common.sh: "rancher-backup")
+set -euo pipefail
+source "$(dirname "$0")/common.sh"
+
+require_var TAG
+require_charts_dir
+
+# Update appVersion context line in Chart.yaml.patch to match the new tag so
+# make prepare applies cleanly (mismatched context causes .orig file creation).
+CHART_PATCH="$CHARTS_DIR/packages/$PACKAGE/generated-changes/patch/Chart.yaml.patch"
+if [ -f "$CHART_PATCH" ]; then
+  awk -v tag="$TAG" '{sub(/appVersion: v[^ ]*/, "appVersion: " tag)}1' "$CHART_PATCH" > "$CHART_PATCH.tmp" && mv "$CHART_PATCH.tmp" "$CHART_PATCH"
+  summary "  - Updated appVersion in Chart.yaml.patch to $TAG"
+fi
+
+make -C "$CHARTS_DIR" prepare PACKAGE="$PACKAGE" USE_CACHE=true
+make -C "$CHARTS_DIR" patch PACKAGE="$PACKAGE" USE_CACHE=true
+make -C "$CHARTS_DIR" clean
+
+commit_if_changed "chore(charts): Refresh rancher-backup chart patches"
+summary "  - Patches refreshed"

--- a/.github/workflows/push-to-charts/update-release-yaml.sh
+++ b/.github/workflows/push-to-charts/update-release-yaml.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Prepend the new combined version to rancher-backup (and rancher-backup-crd) in release.yaml.
+#
+# Prerequisites: generate-assets.sh
+#
+# Inputs (env):
+#   TAG        - BRO release tag (e.g. v9.0.2-rc.5) (required)
+#   CHARTS_DIR - path to rancher/charts clone (required)
+#   PACKAGE    - package name (set by common.sh: "rancher-backup")
+set -euo pipefail
+source "$(dirname "$0")/common.sh"
+
+require_var TAG
+require_charts_dir
+
+TAG_NO_V="${TAG#v}"
+CHARTS_VERSION=$(yq e '.version' "$CHARTS_DIR/packages/$PACKAGE/package.yaml")
+COMBINED_VERSION="${CHARTS_VERSION}+up${TAG_NO_V}"
+
+RELEASE_YAML="$CHARTS_DIR/release.yaml"
+
+yq e -i ".${PACKAGE} |= [\"${COMBINED_VERSION}\"] + ." "$RELEASE_YAML"
+summary "  - Added \`${PACKAGE}\`: \`${COMBINED_VERSION}\`"
+
+CRD_PACKAGE="${PACKAGE}-crd"
+if yq e ".${CRD_PACKAGE}" "$RELEASE_YAML" &>/dev/null; then
+  yq e -i ".${CRD_PACKAGE} |= [\"${COMBINED_VERSION}\"] + ." "$RELEASE_YAML"
+  summary "  - Added \`${CRD_PACKAGE}\`: \`${COMBINED_VERSION}\`"
+fi
+
+if ! git -C "$CHARTS_DIR" diff --quiet --exit-code -- release.yaml; then
+  git -C "$CHARTS_DIR" add release.yaml
+  git -C "$CHARTS_DIR" commit -m "chore(charts): Update release.yaml for rancher-backup ${COMBINED_VERSION}"
+fi


### PR DESCRIPTION
This PR is inspired by @diogoasouza workflow from `ob-team-charts` which we recently refactor to use scripts for the workflow to allow local and remote execution. Using this (when backported to all active branches) it should trigger after a successful release (after `goreleaser` runs) then create a `rancher/charts` PR.