### PR TITLE
Fix Service selector mismatch in rancher-backup metrics Service

### DIFF
--- a/charts/rancher-backup/templates/service.yaml
+++ b/charts/rancher-backup/templates/service.yaml
@@ -19,6 +19,5 @@ spec:
       protocol: TCP
       name: http
   selector:
-    app.kubernetes.io/name: {{ .Release.Name }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- include "backupRestore.selectorLabels" . | nindent 4 }}
 {{ end }}


### PR DESCRIPTION
Issue: https://github.com/rancher/backup-restore-operator/issues/922

**Problem**

When `monitoring.metrics.enabled=true`, `templates/service.yaml` builds the spec.selector  `app.kubernetes.io/name: {{ .Release.Name }}`.

The Deployment derives that same label from `.Chart.Name` instead.

These two values differ when **not** using the "rancher-backup" release name, so the Service never selects any Pod and its Endpoints object is always empty — breaking Prometheus scraping through the ServiceMonitor.

**Fix**
Replace the two hardcoded selector entries in service.yaml with `{{- include "backupRestore.selectorLabels" . | nindent 4 }}`, the same helper already used by the Deployment for both spec.selector.matchLabels and Pod template labels. This ensures the Service selector is always consistent with the Pod labels, regardless of the release name.
```
-    app.kubernetes.io/name: {{ .Release.Name }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- include "backupRestore.selectorLabels" . | nindent 4 }}
```

**Testing**
- Install the helm chart with monitoring.metrics.enabled=true and verify kubectl get endpoints rancher-backup shows the operator Pod IP.
- **Deploy with a non-default release name and verify the selector still matches.**
- No other labels, selectors, or templates are changed.