### PR TITLE
Add imagePullSecrets support to patch-sa hook Job and ServiceAccount

### DIFF
--- a/charts/rancher-backup/templates/hardened.yaml
+++ b/charts/rancher-backup/templates/hardened.yaml
@@ -12,10 +12,9 @@ spec:
   template:
     spec:
       serviceAccountName: {{ include "backupRestore.fullname" . }}-patch-sa
-{{- $pullSecrets := .Values.imagePullSecrets | default .Values.global.imagePullSecrets }}
-{{- if $pullSecrets }}
+{{- if .Values.imagePullSecrets }}
       imagePullSecrets:
-{{ toYaml $pullSecrets | indent 8 }}
+{{ toYaml .Values.imagePullSecrets | indent 8 }}
 {{- end }}
       securityContext:
         runAsNonRoot: true
@@ -44,9 +43,9 @@ metadata:
   annotations:
     "helm.sh/hook": post-install, post-upgrade
     "helm.sh/hook-delete-policy": hook-succeeded, before-hook-creation
-{{- if $pullSecrets }}
+{{- if .Values.imagePullSecrets }}
 imagePullSecrets:
-{{ toYaml $pullSecrets | indent 2 }}
+{{ toYaml .Values.imagePullSecrets | indent 2 }}
 {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/rancher-backup/templates/hardened.yaml
+++ b/charts/rancher-backup/templates/hardened.yaml
@@ -12,6 +12,11 @@ spec:
   template:
     spec:
       serviceAccountName: {{ include "backupRestore.fullname" . }}-patch-sa
+{{- $pullSecrets := .Values.imagePullSecrets | default .Values.global.imagePullSecrets }}
+{{- if $pullSecrets }}
+      imagePullSecrets:
+{{ toYaml $pullSecrets | indent 8 }}
+{{- end }}
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000
@@ -39,6 +44,10 @@ metadata:
   annotations:
     "helm.sh/hook": post-install, post-upgrade
     "helm.sh/hook-delete-policy": hook-succeeded, before-hook-creation
+{{- if $pullSecrets }}
+imagePullSecrets:
+{{ toYaml $pullSecrets | indent 2 }}
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/charts/rancher-backup/tests/hardened_test.yaml
+++ b/charts/rancher-backup/tests/hardened_test.yaml
@@ -1,0 +1,63 @@
+suite: Test Hardened Hook Resources
+templates:
+  - hardened.yaml
+tests:
+- it: should not set imagePullSecrets by default in Job
+  template: hardened.yaml
+  documentIndex: 0
+  asserts:
+    - isNull:
+        path: spec.template.spec.imagePullSecrets
+
+- it: should set imagePullSecrets in Job when defined
+  template: hardened.yaml
+  documentIndex: 0
+  set:
+    imagePullSecrets:
+      - name: my-secret
+  asserts:
+    - equal:
+        path: spec.template.spec.imagePullSecrets[0].name
+        value: my-secret
+
+- it: should use global.imagePullSecrets in Job when local not set
+  template: hardened.yaml
+  documentIndex: 0
+  set:
+    global:
+      imagePullSecrets:
+        - name: global-secret
+  asserts:
+    - equal:
+        path: spec.template.spec.imagePullSecrets[0].name
+        value: global-secret
+
+- it: should not set imagePullSecrets by default in ServiceAccount
+  template: hardened.yaml
+  documentIndex: 1
+  asserts:
+    - isNull:
+        path: imagePullSecrets
+
+- it: should set imagePullSecrets in ServiceAccount
+  template: hardened.yaml
+  documentIndex: 1
+  set:
+    imagePullSecrets:
+      - name: my-secret
+  asserts:
+    - equal:
+        path: imagePullSecrets[0].name
+        value: my-secret
+
+- it: should use global.imagePullSecrets in ServiceAccount
+  template: hardened.yaml
+  documentIndex: 1
+  set:
+    global:
+      imagePullSecrets:
+        - name: global-secret
+  asserts:
+    - equal:
+        path: imagePullSecrets[0].name
+        value: global-secret

--- a/charts/rancher-backup/tests/hardened_test.yaml
+++ b/charts/rancher-backup/tests/hardened_test.yaml
@@ -20,18 +20,6 @@ tests:
         path: spec.template.spec.imagePullSecrets[0].name
         value: my-secret
 
-- it: should use global.imagePullSecrets in Job when local not set
-  template: hardened.yaml
-  documentIndex: 0
-  set:
-    global:
-      imagePullSecrets:
-        - name: global-secret
-  asserts:
-    - equal:
-        path: spec.template.spec.imagePullSecrets[0].name
-        value: global-secret
-
 - it: should not set imagePullSecrets by default in ServiceAccount
   template: hardened.yaml
   documentIndex: 1
@@ -49,15 +37,3 @@ tests:
     - equal:
         path: imagePullSecrets[0].name
         value: my-secret
-
-- it: should use global.imagePullSecrets in ServiceAccount
-  template: hardened.yaml
-  documentIndex: 1
-  set:
-    global:
-      imagePullSecrets:
-        - name: global-secret
-  asserts:
-    - equal:
-        path: imagePullSecrets[0].name
-        value: global-secret


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/54477

Helm hook resources (Job + ServiceAccount) do not inherit imagePullSecrets, causing failures in air-gapped or authenticated registry environments.
This PR propagates` .Values.imagePullSecrets` / `.Values.global.imagePullSecrets` to:
- Hook Job pod spec
- Hook ServiceAccount
