### PR TITLE
ci: Add back `env` field to goreleaser job

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,6 +33,9 @@ jobs:
           version: v0.1.1
 
       - name: Run goreleaser
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GORELEASER_CURRENT_TAG: ${{ github.ref_name }}
         shell: bash
         run: |-
           goreleaser release --clean


### PR DESCRIPTION
To fix:

```
  ⨯ release failed after 0s                          error=missing GITHUB_TOKEN, GITLAB_TOKEN and GITEA_TOKEN
```