### PR TITLE
feat(chart): add extraAnnotations support for rancher-backup pods

### DIFF
--- a/charts/rancher-backup/templates/deployment.yaml
+++ b/charts/rancher-backup/templates/deployment.yaml
@@ -23,6 +23,9 @@ spec:
         prometheus.io/port: "metrics"
         prometheus.io/scrape: "true"
         {{ end }}
+{{- if .Values.extraAnnotations }}
+{{ toYaml .Values.extraAnnotations | indent 8 }}
+{{- end }}
     spec:
       {{- if .Values.securityContext.runAsNonRoot }}
       securityContext:

--- a/charts/rancher-backup/tests/extraAnnotations_test.yaml
+++ b/charts/rancher-backup/tests/extraAnnotations_test.yaml
@@ -1,0 +1,29 @@
+suite: Extra Annotations
+templates:
+  - deployment.yaml
+  - s3-secret.yaml
+  - pvc.yaml
+  - _helpers.tpl
+tests:
+  - it: should set extraAnnotations in rancher-backup deployment
+    set:
+      image.tag: v0.0.0
+      extraAnnotations:
+        test-annotation-1: testvalue1
+        test-annotation-2: testvalue2
+    template: deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations.test-annotation-1
+          value: testvalue1
+      - equal:
+          path: spec.template.metadata.annotations.test-annotation-2
+          value: testvalue2
+  - it: should not set extraAnnotations when empty
+    set:
+      image.tag: v0.0.0
+      extraAnnotations: {}
+    template: deployment.yaml
+    asserts:
+      - notExists:
+          path: spec.template.metadata.annotations.test-annotation-1

--- a/charts/rancher-backup/values.yaml
+++ b/charts/rancher-backup/values.yaml
@@ -129,3 +129,7 @@ resources: {}
   # limits:
   #   cpu: 2
   #   memory: 2Gi
+
+# Extra annotations passed to the rancher-backup pods.
+# extraAnnotations:
+#   new-annotation: "new-annotation-value"


### PR DESCRIPTION
Allow users to pass arbitrary annotations to the rancher-backup pod via extraAnnotations in values.yaml. This enables SUSE Observability autodiscovery annotations (ad.stackstate.com/*) to be injected at deploy time without modifying the chart templates.