### PR TITLE
[Backport v9.x] Add imagePullSecrets support to patch-sa hook Job and ServiceAccount

### DIFF
--- a/charts/rancher-backup/templates/hardened.yaml
+++ b/charts/rancher-backup/templates/hardened.yaml
@@ -12,6 +12,10 @@ spec:
   template:
     spec:
       serviceAccountName: {{ include "backupRestore.fullname" . }}-patch-sa
+{{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets | indent 8 }}
+{{- end }}
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000
@@ -39,6 +43,10 @@ metadata:
   annotations:
     "helm.sh/hook": post-install, post-upgrade
     "helm.sh/hook-delete-policy": hook-succeeded, before-hook-creation
+{{- if .Values.imagePullSecrets }}
+imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets | indent 2 }}
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/charts/rancher-backup/tests/hardened_test.yaml
+++ b/charts/rancher-backup/tests/hardened_test.yaml
@@ -1,0 +1,39 @@
+suite: Test Hardened Hook Resources
+templates:
+  - hardened.yaml
+tests:
+- it: should not set imagePullSecrets by default in Job
+  template: hardened.yaml
+  documentIndex: 0
+  asserts:
+    - isNull:
+        path: spec.template.spec.imagePullSecrets
+
+- it: should set imagePullSecrets in Job when defined
+  template: hardened.yaml
+  documentIndex: 0
+  set:
+    imagePullSecrets:
+      - name: my-secret
+  asserts:
+    - equal:
+        path: spec.template.spec.imagePullSecrets[0].name
+        value: my-secret
+
+- it: should not set imagePullSecrets by default in ServiceAccount
+  template: hardened.yaml
+  documentIndex: 1
+  asserts:
+    - isNull:
+        path: imagePullSecrets
+
+- it: should set imagePullSecrets in ServiceAccount
+  template: hardened.yaml
+  documentIndex: 1
+  set:
+    imagePullSecrets:
+      - name: my-secret
+  asserts:
+    - equal:
+        path: imagePullSecrets[0].name
+        value: my-secret


### PR DESCRIPTION
backport of https://github.com/rancher/backup-restore-operator/pull/935