### PR TITLE
Fix in-place restore for settings webhook validations

### DIFF
--- a/pkg/controllers/restore/controller.go
+++ b/pkg/controllers/restore/controller.go
@@ -992,8 +992,9 @@ func isSettingsWebhookError(gvr schema.GroupVersionResource, err error) bool {
 	}
 	if gvr.Group == "management.cattle.io" && gvr.Resource == "settings" {
 		var statusErr *apierrors.StatusError
-		if errors.As(err, &statusErr) {
-			return strings.Contains(statusErr.ErrStatus.Message, "rancher.cattle.io.settings")
+		if errors.As(err, &statusErr) && statusErr != nil {
+			msg := statusErr.Error()
+			return strings.Contains(msg, "admission webhook") && strings.Contains(msg, "rancher.cattle.io.settings") && strings.Contains(msg, "denied the request")
 		}
 	}
 	return false

--- a/pkg/controllers/restore/controller.go
+++ b/pkg/controllers/restore/controller.go
@@ -706,6 +706,10 @@ func (h *handler) restoreResource(restoreObjInfo objInfo, restoreObjData unstruc
 		// create and return
 		createdObj, err := dr.Create(h.ctx, &obj, k8sv1.CreateOptions{})
 		if err != nil {
+			if isSettingsWebhookError(gvr, err) {
+				logrus.Warnf("restoreResource: skipping setting %s due to webhook admission restriction: %v", name, err)
+				return nil
+			}
 			return fmt.Errorf("restoreResource: err creating resource %v", err)
 		}
 		if hasStatusSubresource && obj.Object["status"] != nil {
@@ -718,11 +722,16 @@ func (h *handler) restoreResource(restoreObjInfo objInfo, restoreObjData unstruc
 		}
 		return nil
 	}
+
 	resMetadata := res.Object[metadataMapKey].(map[string]interface{})
 	resourceVersion := resMetadata["resourceVersion"].(string)
 	obj.Object[metadataMapKey].(map[string]interface{})["resourceVersion"] = resourceVersion
 	updatedObj, err := dr.Update(h.ctx, &obj, k8sv1.UpdateOptions{})
 	if err != nil {
+		if isSettingsWebhookError(gvr, err) {
+			logrus.Warnf("restoreResource: skipping setting %s due to webhook admission restriction: %v", name, err)
+			return nil
+		}
 		return fmt.Errorf("restoreResource: err updating resource %v", err)
 	}
 	if hasStatusSubresource && obj.Object["status"] != nil {
@@ -975,4 +984,17 @@ func crdKind(crd *unstructured.Unstructured) string {
 		return ""
 	}
 	return kind.(string)
+}
+
+func isSettingsWebhookError(gvr schema.GroupVersionResource, err error) bool {
+	if err == nil {
+		return false
+	}
+	if gvr.Group == "management.cattle.io" && gvr.Resource == "settings" {
+		var statusErr *apierrors.StatusError
+		if errors.As(err, &statusErr) {
+			return strings.Contains(statusErr.ErrStatus.Message, "rancher.cattle.io.settings")
+		}
+	}
+	return false
 }

--- a/pkg/controllers/restore/controller_test.go
+++ b/pkg/controllers/restore/controller_test.go
@@ -1,10 +1,14 @@
 package restore
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	k8sv1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 func TestCrdKind(t *testing.T) {
@@ -20,4 +24,90 @@ func TestCrdKind(t *testing.T) {
 	}
 	kind := crdKind(mockCRD)
 	assert.Equal(t, mockKind, kind, "CRD Kind does not match expected value")
+}
+
+func TestIsSettingsWebhookError(t *testing.T) {
+	settingsGVR := schema.GroupVersionResource{
+		Group:    "management.cattle.io",
+		Version:  "v3",
+		Resource: "settings",
+	}
+	unrelatedGVR := schema.GroupVersionResource{
+		Group:    "apps",
+		Version:  "v1",
+		Resource: "deployments",
+	}
+
+	tests := []struct {
+		name     string
+		gvr      schema.GroupVersionResource
+		err      error
+		expected bool
+	}{
+		{
+			name:     "nil error",
+			gvr:      settingsGVR,
+			err:      nil,
+			expected: false,
+		},
+		{
+			name: "read-only setting denied by settings webhook",
+			gvr:  settingsGVR,
+			err: &apierrors.StatusError{
+				ErrStatus: k8sv1.Status{
+					Message: "admission webhook \"rancher.cattle.io.settings\" denied the request: setting is read only",
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "env-sourced setting denied by settings webhook",
+			gvr:  settingsGVR,
+			err: &apierrors.StatusError{
+				ErrStatus: k8sv1.Status{
+					Message: "admission webhook \"rancher.cattle.io.settings\" denied the request: setting cannot be updated since its value is sourced from an environment variable",
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "error from an unrelated webhook",
+			gvr:  settingsGVR,
+			err: &apierrors.StatusError{
+				ErrStatus: k8sv1.Status{
+					Message: "admission webhook \"validation.cattle.io\" denied the request: validation failed",
+				},
+			},
+			expected: false,
+		},
+		{
+			name:     "non-webhook apierror (e.g. NotFound)",
+			gvr:      settingsGVR,
+			err:      apierrors.NewNotFound(schema.GroupResource{Group: "management.cattle.io", Resource: "settings"}, "cacerts"),
+			expected: false,
+		},
+		{
+			name:     "non-webhook generic error",
+			gvr:      settingsGVR,
+			err:      fmt.Errorf("some generic database connection error"),
+			expected: false,
+		},
+		{
+			name: "non-settings GVR with settings-like webhook error message",
+			gvr:  unrelatedGVR,
+			err: &apierrors.StatusError{
+				ErrStatus: k8sv1.Status{
+					Message: "admission webhook \"rancher.cattle.io.settings\" denied the request: setting is read only",
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isSettingsWebhookError(tt.gvr, tt.err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
 }

--- a/pkg/controllers/restore/controller_test.go
+++ b/pkg/controllers/restore/controller_test.go
@@ -102,6 +102,32 @@ func TestIsSettingsWebhookError(t *testing.T) {
 			},
 			expected: false,
 		},
+		{
+			name: "failed calling webhook error",
+			gvr:  settingsGVR,
+			err: &apierrors.StatusError{
+				ErrStatus: k8sv1.Status{
+					Message: "Internal error occurred: failed calling webhook \"rancher.cattle.io.settings\": service \"rancher-webhook\" not found",
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "empty message statuserror falling back to error()",
+			gvr:  settingsGVR,
+			err: &apierrors.StatusError{
+				ErrStatus: k8sv1.Status{
+					Message: "",
+				},
+			},
+			expected: false,
+		},
+		{
+			name:     "typed nil apierror pointer",
+			gvr:      settingsGVR,
+			err:      (*apierrors.StatusError)(nil),
+			expected: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Issue: #981

The admission webhook blocks settings updates for read-only settings, settings sourced from the environment, and settings with invalid formats. These rejections cause the restore to never succeed.

To prevent this, we will log admission webhook rejections for settings as warnings instead of errors.

```
[...]
WARN[2026/06/17 15:18:38] restoreResource: skipping setting cacerts due to webhook admission restriction: admission webhook "rancher.cattle.io.settings.management.cattle.io" denied the request: setting is read only
WARN[2026/06/17 15:18:39] restoreResource: skipping setting auth-user-info-max-age-seconds due to webhook admission restriction: admission webhook "rancher.cattle.io.settings.management.cattle.io" denied the request: value: Invalid value: "": time: invalid duration "s"
[...]
INFO[2026/06/17 15:19:07] Done restoring
```