### PR TITLE
CI Bumps for Rancher 2.15

### DIFF
--- a/.bin-deps.yaml
+++ b/.bin-deps.yaml
@@ -1,4 +1,33 @@
 tools:
+  - name: goreleaser
+    mode: pinned
+    source: goreleaser/goreleaser
+    # renovate: datasource=github-releases depName=goreleaser/goreleaser
+    version: v2.15.3
+    checksums:
+      linux/amd64:  "3b24b3a1629be21a9527d2f46f08b9bbf012c52fe33395714fe2c70acee57e0f"  # renovate-local: goreleaser=v2.15.3
+      linux/arm64:  "646b8f36329cf1ec02af18d40e7096973f62524bdef19c3690414e390a9f757d"  # renovate-local: goreleaser=v2.15.3
+      darwin/amd64: "723ba2f0ad18ec037c9bdd79d787f8a870a66f432706b3b3962b44b3a90def91"  # renovate-local: goreleaser=v2.15.3
+      darwin/arm64: "a46a3bf44ef8255b78d9eae9a3f4da60b878011e8eba7cf12bb3787ad5110418"  # renovate-local: goreleaser=v2.15.3
+    release:
+      download_template: "goreleaser_{os|title}_{arch|replace:amd64=x86_64}.tar.gz"
+      extract: "goreleaser"
+
+  - name: golangci-lint
+    mode: pinned
+    source: golangci/golangci-lint
+    # renovate: datasource=github-releases depName=golangci/golangci-lint
+    version: v2.11.4
+    checksums:
+      linux/amd64:  "200c5b7503f67b59a6743ccf32133026c174e272b930ee79aa2aa6f37aca7ef1"  # renovate-local: golangci-lint=v2.11.4
+      linux/arm64:  "3bcfa2e6f3d32b2bf5cd75eaa876447507025e0303698633f722a05331988db4"  # renovate-local: golangci-lint=v2.11.4
+      darwin/amd64: "c900d4048db75d1edfd550fd11cf6a9b3008e7caa8e119fcddbc700412d63e60"  # renovate-local: golangci-lint=v2.11.4
+      darwin/arm64: "02db2a2dae8b26812e53b0688a6f617e3ef1f489790e829ea22862cf76945675"  # renovate-local: golangci-lint=v2.11.4
+    release:
+      download_template: "golangci-lint-{version|trimprefix:v}-{os}-{arch}.tar.gz"
+      extract: "golangci-lint-{version|trimprefix:v}-{os}-{arch}/golangci-lint"
+      checksum_template: "golangci-lint-{version|trimprefix:v}-checksums.txt"
+
   - name: k3d
     mode: pinned
     source: k3d-io/k3d
@@ -26,3 +55,18 @@ tools:
     release:
       download_template: "kuberlr_{version|trimprefix:v}_{os}_{arch}.tar.gz"
       extract: "kuberlr_{version|trimprefix:v}_{os}_{arch}/kuberlr"
+
+  - name: oras
+    mode: pinned
+    source: oras-project/oras
+    # renovate: datasource=github-release-attachments depName=oras-project/oras
+    version: v1.3.1
+    checksums:
+      darwin/amd64: "22b7d8947d32280283c2e1a2fabc59d3b3c3b3056ec070dabdfe016fda532e52"
+      darwin/arm64: "d545a238f4c8be6dfae6c3d0ff5b09720c5588641d4a5180fb87c38a64500cc4"
+      linux/amd64: "d52c4af76ce6a3ceb8579e51fb751a43ac051cca67f965f973a0b0e897a2bb86"
+      linux/arm64: "79946ad57d732836f9242f903f476b6fa484c451d659f121bce54d931ab2a044"
+    release:
+      download_template: "oras_{version|trimprefix:v}_{os}_{arch}.tar.gz"
+      extract: "oras"
+      checksum_template: "oras_{version|trimprefix:v}_checksums.txt"

--- a/.github/workflows/push-to-charts/common.sh
+++ b/.github/workflows/push-to-charts/common.sh
@@ -20,6 +20,7 @@ PACKAGE="rancher-backup"
 # Map of BRO major version → rancher/charts target branch.
 # Add a new entry here when a new BRO/Rancher version pair is created.
 declare -A CHARTS_BRANCH_MAP=(
+  ["11"]="dev-v2.15"
   ["10"]="dev-v2.14"
   ["9"]="dev-v2.13"
   ["8"]="dev-v2.12"

--- a/charts/rancher-backup/Chart.yaml
+++ b/charts/rancher-backup/Chart.yaml
@@ -7,7 +7,7 @@ annotations:
   catalog.cattle.io/os: linux
   catalog.cattle.io/permits-os: linux,windows
   catalog.cattle.io/provides-gvr: resources.cattle.io.resourceset/v1
-  catalog.cattle.io/rancher-version: '>= 2.14.0-0 < 2.15.0-0'
+  catalog.cattle.io/rancher-version: '>= 2.15.0-0 < 2.16.0-0'
   catalog.cattle.io/release-name: rancher-backup
   catalog.cattle.io/scope: management
   catalog.cattle.io/type: cluster-tool
@@ -25,6 +25,6 @@ keywords:
 - rancher-backup
 maintainers:
   - name: Rancher ORBS Team
-kubeVersion: '>= 1.33.0-0'
+kubeVersion: '>= 1.34.0-0'
 name: rancher-backup
 version: 999


### PR DESCRIPTION
- Bumps k8s version for 2.15 range
- Add 2.15 automation config for charts PRs
- Add back CI tools via `dep-fetch` for now