### PR TITLE
refactor: initialize metrics conditionally

### DIFF
--- a/pkg/monitoring/metrics.go
+++ b/pkg/monitoring/metrics.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	k8sv1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -73,32 +74,40 @@ var (
 			Help: "Number of existing Rancher Restore CRs",
 		},
 	)
+
+	setupMetricsOnce sync.Once
 )
 
-func init() {
-	buckets := defaultRancherBackupDurationBuckets
-	rancherBackupDurationBuckets := os.Getenv("BACKUP_DURATION_BUCKETS")
+// SetupBackupDurationMetric parses duration buckets from the environment and
+// initializes the backupDuration histogram metric. Other metrics in this package
+// are initialized statically on package import.
+func SetupBackupDurationMetric() {
+	setupMetricsOnce.Do(func() {
+		buckets := defaultRancherBackupDurationBuckets
+		rancherBackupDurationBuckets := os.Getenv("BACKUP_DURATION_BUCKETS")
 
-	if rancherBackupDurationBuckets != "" {
-		buckets = []float64{}
-		for _, b := range strings.Split(rancherBackupDurationBuckets, ",") {
-			f, err := strconv.ParseFloat(strings.TrimSpace(b), 64)
-			if err != nil {
-				logrus.Errorf("Failed to parse backup duration bucket '%s': %v", b, err)
-				return
+		if rancherBackupDurationBuckets != "" {
+			buckets = []float64{}
+			for _, b := range strings.Split(rancherBackupDurationBuckets, ",") {
+				f, err := strconv.ParseFloat(strings.TrimSpace(b), 64)
+				if err != nil {
+					logrus.Errorf("Failed to parse backup duration bucket '%s': %v. Falling back to default buckets.", b, err)
+					buckets = defaultRancherBackupDurationBuckets
+					break
+				}
+				buckets = append(buckets, f)
 			}
-			buckets = append(buckets, f)
 		}
-	}
 
-	logrus.Debugf("Backup duration buckets: %v", buckets)
-	backupDuration = promauto.NewHistogramVec(
-		prometheus.HistogramOpts{
-			Name:    "rancher_backup_duration_seconds",
-			Help:    "Duration of each backup processed by this operator in seconds",
-			Buckets: buckets,
-		}, []string{"name"},
-	)
+		logrus.Debugf("Backup duration buckets: %v", buckets)
+		backupDuration = promauto.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Name:    "rancher_backup_duration_seconds",
+				Help:    "Duration of each backup processed by this operator in seconds",
+				Buckets: buckets,
+			}, []string{"name"},
+		)
+	})
 }
 
 func updateBackupMetrics(backups []v1.Backup) {

--- a/pkg/monitoring/metrics_test.go
+++ b/pkg/monitoring/metrics_test.go
@@ -12,6 +12,10 @@ import (
 	k8sv1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+func init() {
+	SetupBackupDurationMetric()
+}
+
 func resetMetrics() {
 	backupDuration.Reset()
 	backupLastProcessed.Reset()

--- a/pkg/operator/start.go
+++ b/pkg/operator/start.go
@@ -233,6 +233,8 @@ func Run(
 	}
 
 	if options.shouldRunMetricsServer() {
+		monitoring.SetupBackupDurationMetric()
+
 		logrus.Info("Starting metrics server")
 		go monitoring.InitMetricsServer(options.MetricsPort)
 


### PR DESCRIPTION
Move the unconditional initialization of rancherBackupDurationBuckets into an explicit SetupBackupDurationMetric() that can be conditionally called, ensuring it only runs one time.

It also adds a fallback mechanism to default buckets when there's an error parsing user provided ones.

Issue: #1011 