### PR TITLE
feat: add BucketLookup to S3 ClientConfig

### DIFF
--- a/charts/rancher-backup-crd/templates/backup.yaml
+++ b/charts/rancher-backup-crd/templates/backup.yaml
@@ -96,6 +96,10 @@ spec:
                             required:
                             - dualStack
                             type: object
+                          bucketLookup:
+                            description: 'BucketLookup controls the bucket lookup
+                              mode. Supported values: "auto", "dns", "path".'
+                            type: string
                         type: object
                       credentialSecretName:
                         type: string

--- a/charts/rancher-backup-crd/templates/restore.yaml
+++ b/charts/rancher-backup-crd/templates/restore.yaml
@@ -90,6 +90,10 @@ spec:
                             required:
                             - dualStack
                             type: object
+                          bucketLookup:
+                            description: 'BucketLookup controls the bucket lookup
+                              mode. Supported values: "auto", "dns", "path".'
+                            type: string
                         type: object
                       credentialSecretName:
                         type: string

--- a/charts/rancher-backup/values.yaml
+++ b/charts/rancher-backup/values.yaml
@@ -25,6 +25,8 @@ s3:
   #   aws:
   #     ## Use dualstack endpoints (IPv6 support); defaults to true
   #     dualStack: false
+  #   ## Bucket lookup mode: "auto", "dns" (virtual hosted style), or "path" (path style); defaults to "auto"
+  #   bucketLookup: "dns"
 
 ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
 ## If persistence is enabled, operator will create a PVC with mountPath /var/lib/backups

--- a/pkg/apis/resources.cattle.io/v1/common.go
+++ b/pkg/apis/resources.cattle.io/v1/common.go
@@ -29,11 +29,13 @@ type S3ObjectStore struct {
 // ClientConfig allows configuration of more advanced minio client settings
 // any provider specific settings will be grouped accordingly, otherwise settings apply to all S3 providers.
 type ClientConfig struct {
-	// TODO: Add setting to control lookup mode
 	// TODO: Add a setting for varying trace options that minio provides
 	// +optional
 	// +nullable
 	Aws *AwsConfig `json:"aws,omitempty"`
+	// BucketLookup controls the bucket lookup mode. Supported values: "auto", "dns", "path".
+	// +optional
+	BucketLookup string `json:"bucketLookup,omitempty"`
 }
 
 // AwsConfig holds AWS-specific S3 configuration.

--- a/pkg/crds/yaml/generated/resources.cattle.io_backups.yaml
+++ b/pkg/crds/yaml/generated/resources.cattle.io_backups.yaml
@@ -96,6 +96,10 @@ spec:
                             required:
                             - dualStack
                             type: object
+                          bucketLookup:
+                            description: 'BucketLookup controls the bucket lookup
+                              mode. Supported values: "auto", "dns", "path".'
+                            type: string
                         type: object
                       credentialSecretName:
                         type: string

--- a/pkg/crds/yaml/generated/resources.cattle.io_restores.yaml
+++ b/pkg/crds/yaml/generated/resources.cattle.io_restores.yaml
@@ -90,6 +90,10 @@ spec:
                             required:
                             - dualStack
                             type: object
+                          bucketLookup:
+                            description: 'BucketLookup controls the bucket lookup
+                              mode. Supported values: "auto", "dns", "path".'
+                            type: string
                         type: object
                       credentialSecretName:
                         type: string

--- a/pkg/generated/openapi/zz_generated_openapi.go
+++ b/pkg/generated/openapi/zz_generated_openapi.go
@@ -352,6 +352,13 @@ func schema_pkg_apis_resourcescattleio_v1_ClientConfig(ref common.ReferenceCallb
 							Ref: ref("github.com/rancher/backup-restore-operator/pkg/apis/resources.cattle.io/v1.AwsConfig"),
 						},
 					},
+					"bucketLookup": {
+						SchemaProps: spec.SchemaProps{
+							Description: "BucketLookup controls the bucket lookup mode. Supported values: \"auto\", \"dns\", \"path\".",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},

--- a/pkg/objectstore/s3minio.go
+++ b/pkg/objectstore/s3minio.go
@@ -65,7 +65,7 @@ func SetS3Service(bc *v1.S3ObjectStore, accessKeyID, secretKey string, useSSL bo
 	var client = &minio.Client{}
 	var cred credentials.Credentials
 	var tr = http.DefaultTransport
-	bucketLookup := getBucketLookupType(bc.Endpoint)
+	bucketLookup := getBucketLookupType(bc)
 	for retries := 0; retries <= s3ServerRetries; retries++ {
 		// if the s3 access key and secret is not set use iam role
 		if len(accessKeyID) == 0 && len(secretKey) == 0 {
@@ -177,11 +177,21 @@ func GetS3Client(ctx context.Context, objectStore *v1.S3ObjectStore, dynamicClie
 	return s3Client, nil
 }
 
-func getBucketLookupType(endpoint string) minio.BucketLookupType {
-	if endpoint == "" {
+func getBucketLookupType(bc *v1.S3ObjectStore) minio.BucketLookupType {
+	if bc == nil {
 		return minio.BucketLookupAuto
 	}
-	if strings.Contains(endpoint, "aliyun") {
+	if bc.ClientConfig != nil && bc.ClientConfig.BucketLookup != "" {
+		switch strings.ToLower(bc.ClientConfig.BucketLookup) {
+		case "dns":
+			return minio.BucketLookupDNS
+		case "path":
+			return minio.BucketLookupPath
+		case "auto":
+			return minio.BucketLookupAuto
+		}
+	}
+	if strings.Contains(bc.Endpoint, "aliyun") {
 		return minio.BucketLookupDNS
 	}
 	return minio.BucketLookupAuto

--- a/pkg/objectstore/s3minio_test.go
+++ b/pkg/objectstore/s3minio_test.go
@@ -3,6 +3,8 @@ package objectstore
 import (
 	"testing"
 
+	"github.com/minio/minio-go/v7"
+	v1 "github.com/rancher/backup-restore-operator/pkg/apis/resources.cattle.io/v1"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -47,6 +49,88 @@ func Test_redactAccessKeyID(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			result := redactAccessKeyID(test.input)
+			assert.Equal(t, test.expected, result)
+		})
+	}
+}
+
+func Test_getBucketLookupType(t *testing.T) {
+	tests := []struct {
+		name     string
+		bc       *v1.S3ObjectStore
+		expected minio.BucketLookupType
+	}{
+		{
+			name:     "default lookup when S3ObjectStore is nil",
+			bc:       nil,
+			expected: minio.BucketLookupAuto,
+		},
+		{
+			name: "default lookup when config is nil and endpoint is AWS",
+			bc: &v1.S3ObjectStore{
+				Endpoint: "s3.amazonaws.com",
+			},
+			expected: minio.BucketLookupAuto,
+		},
+		{
+			name: "default lookup when config is nil and endpoint is empty",
+			bc: &v1.S3ObjectStore{
+				Endpoint: "",
+			},
+			expected: minio.BucketLookupAuto,
+		},
+		{
+			name: "aliyun endpoint defaults to DNS",
+			bc: &v1.S3ObjectStore{
+				Endpoint: "oss-cn-hangzhou.aliyuncs.com",
+			},
+			expected: minio.BucketLookupDNS,
+		},
+		{
+			name: "force lookup type to dns via clientConfig",
+			bc: &v1.S3ObjectStore{
+				Endpoint: "obs.eu-west-101.myhuaweicloud.eu",
+				ClientConfig: &v1.ClientConfig{
+					BucketLookup: "dns",
+				},
+			},
+			expected: minio.BucketLookupDNS,
+		},
+		{
+			name: "force lookup type to path via clientConfig",
+			bc: &v1.S3ObjectStore{
+				Endpoint: "s3.amazonaws.com",
+				ClientConfig: &v1.ClientConfig{
+					BucketLookup: "path",
+				},
+			},
+			expected: minio.BucketLookupPath,
+		},
+		{
+			name: "force lookup type to auto via clientConfig",
+			bc: &v1.S3ObjectStore{
+				Endpoint: "oss-cn-hangzhou.aliyuncs.com",
+				ClientConfig: &v1.ClientConfig{
+					BucketLookup: "auto",
+				},
+			},
+			expected: minio.BucketLookupAuto,
+		},
+		{
+			name: "invalid lookup type in clientConfig falls back to endpoint default",
+			bc: &v1.S3ObjectStore{
+				Endpoint: "oss-cn-hangzhou.aliyuncs.com",
+				ClientConfig: &v1.ClientConfig{
+					BucketLookup: "invalid",
+				},
+			},
+			expected: minio.BucketLookupDNS,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := getBucketLookupType(test.bc)
 			assert.Equal(t, test.expected, result)
 		})
 	}


### PR DESCRIPTION
Add a new BucketLookup field to the S3 ClientConfig struct to configure the bucket lookup style ("auto", "dns", "path"). It also preserves the previous behaviour by default ("auto" unless the Endpoint contains "aliyun"). Add unit tests to cover the getBucketLookupType() function.

Issue: #973