### PR TITLE
feat: Support Kubewarden 1.37 `admission-controller` chart 

### DIFF
--- a/charts/rancher-backup/files/optional/basic-resourceset-contents/kubewarden.yaml
+++ b/charts/rancher-backup/files/optional/basic-resourceset-contents/kubewarden.yaml
@@ -44,18 +44,18 @@
   kindsRegexp: "."
   resourceNameRegexp: "openreports.io$"
 
-# kubewarden-controller deployment
+# admission-controller deployment
 - apiVersion: "apps/v1"
   kindsRegexp: "^deployments$"
   namespaceRegexp: "^cattle-kubewarden-|^kubewarden"
   resourceNames:
-    - "kubewarden-controller"
+    - "admission-controller"
     
 # policyservers, policies in all ns
 - apiVersion: "policies.kubewarden.io/v1"
   kindsRegexp: "."
 
-# kubewarden webhook configurations exposed by the kubewarden-controller
+# kubewarden webhook configurations exposed by the admission-controller
 # (not the ones which the controller reconciles that connect to each policy-server)
 - apiVersion: "admissionregistration.k8s.io/v1"
   kindsRegexp: "^WebhookConfiguration$"
@@ -75,7 +75,7 @@
     matchExpressions:
     - key: "app.kubernetes.io/instance"
       operator: "In"
-      values: ["kubewarden-controller"]
+      values: ["admission-controller"]
     - key: "app.kubernetes.io/name"
       operator: "In"
       values: ["policy-reporter", "policy-reporter-ui"]
@@ -86,7 +86,7 @@
     matchExpressions:
     - key: "app.kubernetes.io/instance"
       operator: "In"
-      values: ["kubewarden-controller"]
+      values: ["admission-controller"]
     - key: "app.kubernetes.io/name"
       operator: "In"
       values: ["policy-reporter", "policy-reporter-ui"]
@@ -96,7 +96,7 @@
     matchExpressions:
     - key: "app.kubernetes.io/instance"
       operator: "In"
-      values: ["kubewarden-controller"]
+      values: ["admission-controller"]
     - key: "app.kubernetes.io/name"
       operator: "In"
       values: ["policy-reporter", "policy-reporter-ui"]
@@ -107,7 +107,7 @@
     matchExpressions:
     - key: "app.kubernetes.io/instance"
       operator: "In"
-      values: ["kubewarden-controller"]
+      values: ["admission-controller"]
     - key: "app.kubernetes.io/name"
       operator: "In"
       values: ["policy-reporter", "policy-reporter-ui"]
@@ -118,7 +118,7 @@
     matchExpressions:
     - key: "app.kubernetes.io/instance"
       operator: "In"
-      values: ["kubewarden-controller"]
+      values: ["admission-controller"]
     - key: "app.kubernetes.io/name"
       operator: "In"
       values: ["policy-reporter", "policy-reporter-ui"]
@@ -129,7 +129,7 @@
     matchExpressions:
     - key: "app.kubernetes.io/instance"
       operator: "In"
-      values: ["kubewarden-controller"]
+      values: ["admission-controller"]
     - key: "app.kubernetes.io/name"
       operator: "In"
       values: ["policy-reporter", "policy-reporter-ui"]
@@ -139,7 +139,7 @@
     matchExpressions:
     - key: "app.kubernetes.io/instance"
       operator: "In"
-      values: ["kubewarden-controller"]
+      values: ["admission-controller"]
     - key: "app.kubernetes.io/name"
       operator: "In"
       values: ["policy-reporter", "policy-reporter-ui"]
@@ -150,7 +150,7 @@
     matchExpressions:
     - key: "app.kubernetes.io/instance"
       operator: "In"
-      values: ["kubewarden-controller"]
+      values: ["admission-controller"]
     - key: "app.kubernetes.io/name"
       operator: "In"
       values: ["policy-reporter", "policy-reporter-ui"]


### PR DESCRIPTION
#### Description

With 1.37, Kubewarden admission controller migrated from 3 charts:
  `kubewarden-crds`, `kubewarden-controller`, `kubewarden-defaults`
to 1:
  `admission-controller`

Besides some resource names and label name changes, nothing changed (see changelog blogpost: https://www.kubewarden.io/blog/2026/07/admission-controller-1.37-release)

Update the resourceset contents to the new `admission-controller` Helm chart.

#### Tests

Tested by performing a backup and restore following the steps in https://docs.kubewarden.io/admission-controller/1.37/en/howtos/rancher-backup-operator.html

```console
# deploy kubewarden 1.37
minikube start
helm upgrade -i --wait --devel \
    --namespace kubewarden \
    --create-namespace \
    admission-controller kubewarden/admission-controller \
    --set auditScanner.cronJob.schedule="*/1 * * * *" \
    --set auditScanner.policyReporter=true \
    --set recommendedPolicies.enabled=True \
    --set recommendedPolicies.defaultPolicyMode=monitor
    
# deploy 2 additional Kubewarden CRs that will get restored    
kubectl apply -f policy-safe-labels.yaml
kubectl apply -f policyserver-custom.yml

# install backup-operator with the changes from this PR
helm install --wait --create-namespace -n cattle-resources-system \
    rancher-backup-crd rancher-charts/rancher-backup-crd
(patch charts/rancher-backup/values.yaml.tag with `v11.0.1`)
helm install --wait -n cattle-resources-system rancher-backup ./rancher-backup --set persistence.enabled=true --set persistence.storageClass=standard --set optionalResources.kubewarden.enabled=true

# backup
vic@viccuad ~/suse/backup-restore-operator/charts (feat/kubewarden-controller-migration *)$ kubectl apply -f - <<EOF
apiVersion: resources.cattle.io/v1
kind: Backup
metadata:
  name: default-location-backup
spec:
  resourceSetName: rancher-resource-set-full
EOF
backup.resources.cattle.io/default-location-backup created
kubectl logs -n cattle-resources-system -l app.kubernetes.io/name=rancher-backup -f
INFO[2026/08/07 09:32:26] retentionCount set to: 1 for default-location-backup
INFO[2026/08/07 09:32:26] For backup CR default-location-backup, filename: default-location-backup-f3f82f2b-da6f-4406-ad42-1e1e9e0b8187-2026-08-07T09-32-26Z
INFO[2026/08/07 09:32:26] Temporary backup path for storing all contents for backup CR default-location-backup is /tmp/default-location-backup-f3f82f2b-da6f-4406-ad42-1e1e9e0b8187-2026-08-07T09-32-26Z1244783984
INFO[2026/08/07 09:32:26] Using resourceSet rancher-resource-set-full for gathering resources for backup CR default-location-backup
INFO[2026/08/07 09:32:26] Gathering resources for backup CR default-location-backup
INFO[2026/08/07 09:32:26] Finished gathering resources for backup CR default-location-backup, writing to temp location
INFO[2026/08/07 09:32:26] Saving resourceSet used for backup CR default-location-backup
INFO[2026/08/07 09:32:26] No storage location specified, checking for default PVC and S3
INFO[2026/08/07 09:32:26] Compressing backup CR default-location-backup
INFO[2026/08/07 09:32:26] Done with backup

kubectl get backups
NAME                      LOCATION   TYPE       LATEST-BACKUP                                                                              RESOURCESET                 AGE   STATUS
default-location-backup   PV         One-time   default-location-backup-f3f82f2b-da6f-4406-ad42-1e1e9e0b8187-2026-08-07T09-32-26Z.tar.gz   rancher-resource-set-full   17s   Completed

# Restore
kubectl apply -f - <<EOF
apiVersion: resources.cattle.io/v1
kind: Restore
metadata:
  name: restore-default
spec:
  backupFilename: default-location-backup-f3f82f2b-da6f-4406-ad42-1e1e9e0b8187-2026-08-07T09-32-26Z.tar.gz
EOF
$ kubectl get restores
NAME              BACKUP-SOURCE   BACKUP-FILE                                                                                AGE   STATUS
restore-default   PV              default-location-backup-f3f82f2b-da6f-4406-ad42-1e1e9e0b8187-2026-08-07T09-32-26Z.tar.gz    7s    Completed

# check that the custom policyserver and the safe-labels policy are around, together with the other recommended policies, and the rest of kubewarden admission-controller.
```