### PR TITLE
[release/v8.x] deps: update go to v1.26.6

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,4 +1,5 @@
-FROM rancher/hardened-build-base:v1.25.12b1 AS builder
+ARG GO_IMAGE=rancher/hardened-build-base:v1.26.6b1
+FROM ${GO_IMAGE} AS builder
 
 ARG TAG=''
 ARG REPO=''


### PR DESCRIPTION
- [rancher/backup-restore-operator:v7.0.10-rc.3](https://github.com/rancherlabs/image-scanning/issues/11709)
- [rancher/backup-restore-operator:v8.1.8-rc.3](https://github.com/rancherlabs/image-scanning/issues/11710)
- [rancher/backup-restore-operator:v9.0.7-rc.3](https://github.com/rancherlabs/image-scanning/issues/11711)
- [rancher/backup-restore-operator:v10.0.9-rc.2](https://github.com/rancherlabs/image-scanning/issues/11707)
- [rancher/backup-restore-operator:v11.0.2-rc.1](https://github.com/rancherlabs/image-scanning/issues/11708)
