### PR TITLE
Deploy automation-core workflows to main

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -26,7 +26,7 @@ jobs:
           secret/data/github/org/rancher/fossa/push token | FOSSA_API_KEY_PUSH_ONLY
 
     - name: FOSSA scan
-      uses: fossas/fossa-action@ff70fe9fe17cbd2040648f1c45e8ec4e4884dcf3 # v1.9.0
+      uses: fossas/fossa-action@29693cc50323968e039056be419b32989fc5880c # v2.0.0
       with:
         api-key: ${{ env.FOSSA_API_KEY_PUSH_ONLY }}
         # Only runs the scan and do not provide/returns any results back to the

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,7 +33,7 @@ jobs:
 
       # SLSA attestation stays on release branch (OIDC binding requirement)
       - name: Attest build provenance
-        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
         with:
           subject-path: dist/backup-restore-operator_*, build/artifacts/*.tgz
 
@@ -46,7 +46,7 @@ jobs:
     runs-on: runs-on,image=ubuntu22-full-x64,runner=4cpu-linux-x64,run-id=${{ github.run_id }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       # Vault secrets read on release branch
       - name: "Read vault secrets"
@@ -61,7 +61,7 @@ jobs:
 
       # This encapsulates: login, qemu, build/push
       - name: Build and push BRO image (dockerhub and prime stg)
-        uses: rancher/ecm-distro-tools/actions/publish-image@b558c3371d4a363f131e31a87d5c47dae2bbebe7 # v0.75.1
+        uses: rancher/ecm-distro-tools/actions/publish-image@4b93308a7a0a096e6001cda6a7b34f5bda215d13 # v0.74.2
         with:
           image: "backup-restore-operator"
           tag: ${{ github.ref_name }}
@@ -91,7 +91,7 @@ jobs:
 
       - name: Build and push BRO image (prime prod)
         if: ${{ steps.semver_check.outputs.HAS_PRERELEASE == 'false' }}
-        uses: rancher/ecm-distro-tools/actions/publish-image@b558c3371d4a363f131e31a87d5c47dae2bbebe7 # v0.75.1
+        uses: rancher/ecm-distro-tools/actions/publish-image@4b93308a7a0a096e6001cda6a7b34f5bda215d13 # v0.74.2
         with:
           image: "backup-restore-operator"
           tag: ${{ github.ref_name }}


### PR DESCRIPTION
**Automated deployment of automation-core workflows**

## Configuration
- **K3S versions**: `["v1.34.5-k3s1","v1.36.1-k3s1"]`
- **Automation-core ref**: `@automation-core`
- **Target branch**: `main`

## Changes
This PR updates the GitHub Actions workflows from automation-core templates.

## Source
- Automation-core commit: `c175486`
- Deployed by: @danpock

---
🤖 Generated by automation-core workflow deployment
