### PR TITLE
Deploy automation-core workflows to release/v10.x

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 30
     steps:
     - name: Checkout
-      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     # The FOSSA token is shared between all repos in Rancher's GH org. It can be
     # used directly and there is no need to request specific access to EIO.
@@ -26,7 +26,7 @@ jobs:
           secret/data/github/org/rancher/fossa/push token | FOSSA_API_KEY_PUSH_ONLY
 
     - name: FOSSA scan
-      uses: fossas/fossa-action@c414b9ad82eaad041e47a7cf62a4f02411f427a0 # v1.8.0
+      uses: fossas/fossa-action@29693cc50323968e039056be419b32989fc5880c # v2.0.0
       with:
         api-key: ${{ env.FOSSA_API_KEY_PUSH_ONLY }}
         # Only runs the scan and do not provide/returns any results back to the


### PR DESCRIPTION
**Automated deployment of automation-core workflows**

## Configuration
- **K3S versions**: `["v1.33.8-k3s1","v1.35.1-k3s1"]`
- **Automation-core ref**: `@automation-core`
- **Target branch**: `release/v10.x`

## Changes
This PR updates the GitHub Actions workflows from automation-core templates.

## Source
- Automation-core commit: `c175486`
- Deployed by: @danpock

---
🤖 Generated by automation-core workflow deployment
