### PR TITLE
Deploy automation-core workflows to release/v8.x

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -1,0 +1,34 @@
+name: FOSSA Scanning
+
+on:
+  push:
+    branches: ["main", "master", "release/**"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  fossa-scanning:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+    - name: Checkout
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+    # The FOSSA token is shared between all repos in Rancher's GH org. It can be
+    # used directly and there is no need to request specific access to EIO.
+    - name: Read FOSSA token
+      uses: rancher-eio/read-vault-secrets@0da85151ad1f19ed7986c41587e45aac1ace74b6 # v3
+      with:
+        secrets: |
+          secret/data/github/org/rancher/fossa/push token | FOSSA_API_KEY_PUSH_ONLY
+
+    - name: FOSSA scan
+      uses: fossas/fossa-action@29693cc50323968e039056be419b32989fc5880c # v2.0.0
+      with:
+        api-key: ${{ env.FOSSA_API_KEY_PUSH_ONLY }}
+        # Only runs the scan and do not provide/returns any results back to the
+        # pipeline.
+        run-tests: false


### PR DESCRIPTION
**Automated deployment of automation-core workflows**

## Configuration
- **K3S versions**: `["v1.31.14-k3s1","v1.33.10-k3s1"]`
- **Automation-core ref**: `@automation-core`
- **Target branch**: `release/v8.x`

## Changes
This PR updates the GitHub Actions workflows from automation-core templates.

## Source
- Automation-core commit: `c175486`
- Deployed by: @danpock

---
🤖 Generated by automation-core workflow deployment
